### PR TITLE
Simplify implementations with tile() function

### DIFF
--- a/bench/blasfeo/Gemm.cpp
+++ b/bench/blasfeo/Gemm.cpp
@@ -53,7 +53,7 @@ namespace blast :: benchmark
         for (auto _ : state)
             gemm_nt(m, n, k, 1., A, 0, 0, B, 0, 0, 1., C, 0, 0, C, 0, 0);
 
-        state.counters["flops"] = Counter(2 * m * m * m, Counter::kIsIterationInvariantRate);
+        state.counters["flops"] = Counter(2 * m * n * k + 3 * m * n, Counter::kIsIterationInvariantRate);
         state.counters["m"] = m;
     }
 

--- a/bench/blast/math/dense/StaticGemm.cpp
+++ b/bench/blast/math/dense/StaticGemm.cpp
@@ -32,15 +32,14 @@ namespace blast :: benchmark
 
         for (auto _ : state)
         {
-            // gemm(1., A, trans(B), 1., C, D);
-            gemm(A, B, C, D);
+            gemm(0.5, A, B, 0.1, C, D);
             DoNotOptimize(A);
             DoNotOptimize(B);
             DoNotOptimize(C);
             DoNotOptimize(D);
         }
 
-        state.counters["flops"] = Counter(2 * M * N * K, Counter::kIsIterationInvariantRate);
+        state.counters["flops"] = Counter(2 * M * N * K + 3 * M * N, Counter::kIsIterationInvariantRate);
         state.counters["m"] = M;
     }
 

--- a/include/blast/math/StorageOrder.hpp
+++ b/include/blast/math/StorageOrder.hpp
@@ -24,4 +24,10 @@ namespace blast
         rowMajor = blaze::rowMajor,
         columnMajor = blaze::columnMajor
     };
+
+
+    inline constexpr StorageOrder operator!(StorageOrder so)
+    {
+        return so == rowMajor ? columnMajor : rowMajor;
+    }
 }

--- a/include/blast/math/algorithm/Gemm.hpp
+++ b/include/blast/math/algorithm/Gemm.hpp
@@ -61,7 +61,9 @@ namespace blast
         BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE(std::remove_cv_t<ElementType_t<MPC>>, ET);
         BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE(std::remove_cv_t<ElementType_t<MPD>>, ET);
 
-        tile<ET, StorageOrder(StorageOrder_v<MPD>)>(M, N,
+        tile<ET, StorageOrder(StorageOrder_v<MPD>)>(
+            D.cachePreferredTraversal,
+            M, N,
             [&] (auto& ker, size_t i, size_t j)
             {
                 gemm(ker, K, alpha, A(i, 0), B(0, j), beta, C(i, j), D(i, j));

--- a/include/blast/math/algorithm/Tile.hpp
+++ b/include/blast/math/algorithm/Tile.hpp
@@ -14,6 +14,7 @@
 
 #include <blast/system/Tile.hpp>
 #include <blast/system/Inline.hpp>
+#include <blast/math/simd/SimdSize.hpp>
 #include <blast/math/StorageOrder.hpp>
 #include <blast/math/RegisterMatrix.hpp>
 
@@ -22,6 +23,34 @@
 
 namespace blast
 {
+    template <typename ET, size_t KM, size_t KN, StorageOrder SO, typename FF, typename FP>
+    BLAZE_ALWAYS_INLINE void tile_backend(size_t m, size_t n, size_t i, FF&& f_full, FP&& f_partial)
+    {
+        RegisterMatrix<ET, KM, KN, SO> ker;
+
+        if (i + KM <= m)
+        {
+            size_t j = 0;
+
+            for (; j + KN <= n; j += KN)
+                f_full(ker, i, j);
+
+            if (j < n)
+                f_partial(ker, i, j, KM, n - j);
+        }
+        else
+        {
+            size_t j = 0;
+
+            for (; j + KN <= n; j += KN)
+                f_partial(ker, i, j, m - i, KN);
+
+            if (j < n)
+                f_partial(ker, i, j, m - i, n - j);
+        }
+    }
+
+
     /**
      * @brief Cover a matrix with tiles of different sizes in a performance-efficient way.
      *
@@ -48,77 +77,98 @@ namespace blast
      * @param f_partial functor to call on partial tiles
      */
     template <typename ET, StorageOrder SO, typename FF, typename FP>
-    BLAST_ALWAYS_INLINE void tile(std::size_t m, std::size_t n, FF&& f_full, FP&& f_partial)
+    BLAST_ALWAYS_INLINE void tile(StorageOrder traversal_order, std::size_t m, std::size_t n, FF&& f_full, FP&& f_partial)
     {
-        size_t constexpr TILE_SIZE = TileSize_v<ET>;
+        size_t constexpr SS = SimdSize_v<ET>;
+        size_t constexpr TILE_STEP = 4;    // TODO: this is almost arbitrary and needs to be ppoperly determined
 
-        size_t j = 0;
+        static_assert(SO == columnMajor, "tile() for row-major matrices not implemented");
 
-        // Main part
-        for (; j + TILE_SIZE <= n; j += TILE_SIZE)
+        if (traversal_order == columnMajor)
         {
-            size_t i = 0;
+            size_t j = 0;
 
-            // i + 4 * TILE_SIZE != M is to improve performance in case when the remaining number of rows is 4 * TILE_SIZE:
-            // it is more efficient to apply 2 * TILE_SIZE kernel 2 times than 3 * TILE_SIZE + 1 * TILE_SIZE kernel.
-            for (; i + 3 * TILE_SIZE <= m && i + 4 * TILE_SIZE != m; i += 3 * TILE_SIZE)
+            // Main part
+            for (; j + TILE_STEP <= n; j += TILE_STEP)
             {
-                RegisterMatrix<ET, 3 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                f_full(ker, i, j);
+                size_t i = 0;
+
+                // i + 4 * TILE_SIZE != M is to improve performance in case when the remaining number of rows is 4 * TILE_SIZE:
+                // it is more efficient to apply 2 * TILE_SIZE kernel 2 times than 3 * TILE_SIZE + 1 * TILE_SIZE kernel.
+                for (; i + 3 * SS <= m && i + 4 * SS != m; i += 3 * SS)
+                {
+                    RegisterMatrix<ET, 3 * SS, TILE_STEP, SO> ker;
+                    f_full(ker, i, j);
+                }
+
+                for (; i + 2 * SS <= m; i += 2 * SS)
+                {
+                    RegisterMatrix<ET, 2 * SS, TILE_STEP, SO> ker;
+                    f_full(ker, i, j);
+                }
+
+                for (; i + 1 * SS <= m; i += 1 * SS)
+                {
+                    RegisterMatrix<ET, 1 * SS, TILE_STEP, SO> ker;
+                    f_full(ker, i, j);
+                }
+
+                // Bottom side
+                if (i < m)
+                {
+                    RegisterMatrix<ET, SS, TILE_STEP, SO> ker;
+                    f_partial(ker, i, j, m - i, ker.columns());
+                }
             }
 
-            for (; i + 2 * TILE_SIZE <= m; i += 2 * TILE_SIZE)
-            {
-                RegisterMatrix<ET, 2 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                f_full(ker, i, j);
-            }
 
-            for (; i + 1 * TILE_SIZE <= m; i += 1 * TILE_SIZE)
+            // Right side
+            if (j < n)
             {
-                RegisterMatrix<ET, 1 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                f_full(ker, i, j);
-            }
+                size_t i = 0;
 
-            // Bottom side
-            if (i < m)
-            {
-                RegisterMatrix<ET, TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                f_partial(ker, i, j, m - i, ker.columns());
+                // i + 4 * TILE_STEP != M is to improve performance in case when the remaining number of rows is 4 * TILE_STEP:
+                // it is more efficient to apply 2 * TILE_STEP kernel 2 times than 3 * TILE_STEP + 1 * TILE_STEP kernel.
+                for (; i + 3 * SS <= m && i + 4 * SS != m; i += 3 * SS)
+                {
+                    RegisterMatrix<ET, 3 * SS, TILE_STEP, SO> ker;
+                    f_partial(ker, i, j, ker.rows(), n - j);
+                }
+
+                for (; i + 2 * SS <= m; i += 2 * SS)
+                {
+                    RegisterMatrix<ET, 2 * SS, TILE_STEP, SO> ker;
+                    f_partial(ker, i, j, ker.rows(), n - j);
+                }
+
+                for (; i + 1 * SS <= m; i += 1 * SS)
+                {
+                    RegisterMatrix<ET, 1 * SS, TILE_STEP, SO> ker;
+                    f_partial(ker, i, j, ker.rows(), n - j);
+                }
+
+                // Bottom-right corner
+                if (i < m)
+                {
+                    RegisterMatrix<ET, SS, TILE_STEP, SO> ker;
+                    f_partial(ker, i, j, m - i, n - j);
+                }
             }
         }
-
-
-        // Right side
-        if (j < n)
+        else
         {
             size_t i = 0;
 
-            // i + 4 * TILE_SIZE != M is to improve performance in case when the remaining number of rows is 4 * TILE_SIZE:
-            // it is more efficient to apply 2 * TILE_SIZE kernel 2 times than 3 * TILE_SIZE + 1 * TILE_SIZE kernel.
-            for (; i + 3 * TILE_SIZE <= m && i + 4 * TILE_SIZE != m; i += 3 * TILE_SIZE)
-            {
-                RegisterMatrix<ET, 3 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                f_partial(ker, i, j, ker.rows(), n - j);
-            }
+            // i + 4 * SS != M is to improve performance in case when the remaining number of rows is 4 * SS:
+            // it is more efficient to apply 2 * SS kernel 2 times than 3 * SS + 1 * SS kernel.
+            for (; i + 2 * SS < m && i + 4 * SS != m; i += 3 * SS)
+                tile_backend<ET, 3 * SS, TILE_STEP, SO>(m, n, i, f_full, f_partial);
 
-            for (; i + 2 * TILE_SIZE <= m; i += 2 * TILE_SIZE)
-            {
-                RegisterMatrix<ET, 2 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                f_partial(ker, i, j, ker.rows(), n - j);
-            }
+            for (; i + 1 * SS < m; i += 2 * SS)
+                tile_backend<ET, 2 * SS, TILE_STEP, SO>(m, n, i, f_full, f_partial);
 
-            for (; i + 1 * TILE_SIZE <= m; i += 1 * TILE_SIZE)
-            {
-                RegisterMatrix<ET, 1 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                f_partial(ker, i, j, ker.rows(), n - j);
-            }
-
-            // Bottom-right corner
-            if (i < m)
-            {
-                RegisterMatrix<ET, TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                f_partial(ker, i, j, m - i, n - j);
-            }
+            for (; i + 0 * SS < m; i += 1 * SS)
+                tile_backend<ET, 1 * SS, TILE_STEP, SO>(m, n, i, f_full, f_partial);
         }
     }
 }

--- a/include/blast/math/dense/DynamicMatrixPointer.hpp
+++ b/include/blast/math/dense/DynamicMatrixPointer.hpp
@@ -31,6 +31,7 @@ namespace blast
         static bool constexpr aligned = AF;
         static bool constexpr padded = PF;
         static bool constexpr isStatic = false;
+        static StorageOrder constexpr cachePreferredTraversal = SO == columnMajor ? columnMajor : rowMajor;
 
 
         /**

--- a/include/blast/math/dense/StaticMatrixPointer.hpp
+++ b/include/blast/math/dense/StaticMatrixPointer.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <blast/math/StorageOrder.hpp>
 #include <blast/math/TransposeFlag.hpp>
 #include <blast/math/simd/Simd.hpp>
 #include <blast/math/simd/SimdVec.hpp>
@@ -31,6 +32,7 @@ namespace blast
         static bool constexpr aligned = AF;
         static bool constexpr padded = PF;
         static bool constexpr isStatic = true;
+        static StorageOrder constexpr cachePreferredTraversal = SO == columnMajor ? columnMajor : rowMajor;
 
 
         /**

--- a/include/blast/math/expressions/PanelMatrix.hpp
+++ b/include/blast/math/expressions/PanelMatrix.hpp
@@ -108,7 +108,7 @@ namespace blast
 
 			for (size_t i = 0; i + SS <= m; i += SS)
             {
-                ET2 const * pr = (*rhs).ptr(i, 0);
+                ET2 const * pr = &(*rhs)(i, 0);
                 ET1 * pl = data(lhs) + i;
 
                 for (size_t j = 0; j < n; ++j)
@@ -119,7 +119,7 @@ namespace blast
             {
                 MaskType const mask = SIMD::index() < rem;
                 size_t const i = m - rem;
-                ET2 const * pr = (*rhs).ptr(i, 0);
+                ET2 const * pr = &(*rhs)(i, 0);
                 ET1 * pl = data(lhs) + i;
 
                 for (size_t j = 0; j < n; ++j)
@@ -197,7 +197,7 @@ namespace blast
 			for (size_t i = 0; i + SS <= m; i += SS)
             {
                 ET2 const * pr = data(rhs) + i;
-                ET1 * pl = (*lhs).ptr(i, 0);
+                ET1 * pl = &(*lhs)(i, 0);
 
                 for (size_t j = 0; j < n; ++j)
                     store<aligned>(pl + PANEL_SIZE * j, load<aligned, SS>(pr + s * j));
@@ -207,7 +207,7 @@ namespace blast
             {
                 size_t const i = m - rem;
                 ET2 const * pr = data(rhs) + i;
-                ET1 * pl = (*lhs).ptr(i, 0);
+                ET1 * pl = &(*lhs)(i, 0);
 
                 for (size_t j = 0; j < n; ++j)
                     for (size_t i1 = 0; i1 < rem; ++i1)
@@ -230,7 +230,7 @@ namespace blast
 			for (size_t i = 0; i < m; ++i)
             {
                 ET2 const * pr = data(rhs) + s * i;
-                ET1 * pl = (*lhs).ptr(i, 0);
+                ET1 * pl = &(*lhs)(i, 0);
 
                 for (size_t j = 0; j < n; ++j)
                     pl[PANEL_SIZE * j] = pr[j];

--- a/include/blast/math/panel/DynamicPanelMatrix.hpp
+++ b/include/blast/math/panel/DynamicPanelMatrix.hpp
@@ -146,23 +146,6 @@ namespace blast
         }
 
 
-        /// @brief Offset of the first matrix element from the start of the panel.
-        ///
-        /// In rows for column-major matrices, in columns for row-major matrices.
-        size_t constexpr offset() const
-        {
-            return 0;
-        }
-
-
-        void unpackLower(Type * data, size_t lda) const
-        {
-            for (size_t i = 0; i < m_; ++i)
-                for (size_t j = 0; j <= i; ++j)
-                    data[i + lda * j] = (*this)(i, j);
-        }
-
-
         Type * data() noexcept
         {
             return v_;
@@ -172,32 +155,6 @@ namespace blast
         Type const * data() const noexcept
         {
             return v_;
-        }
-
-
-        Type * ptr(size_t i, size_t j)
-        {
-            // BLAST_USER_ASSERT(i % panelSize_ == 0, "Row index not aligned to panel boundary");
-            return v_ + elementIndex(i, j);
-        }
-
-
-        Type const * ptr(size_t i, size_t j) const
-        {
-            // BLAST_USER_ASSERT(i % panelSize_ == 0, "Row index not aligned to panel boundary");
-            return v_ + elementIndex(i, j);
-        }
-
-
-        template <size_t SS>
-        auto load(size_t i, size_t j) const
-        {
-            BLAZE_INTERNAL_ASSERT(i < m_, "Invalid row access index");
-            BLAZE_INTERNAL_ASSERT(j < n_, "Invalid column access index");
-            BLAZE_INTERNAL_ASSERT(i % panelSize_ == 0 || SO == rowMajor, "Row index not aligned to panel boundary");
-            BLAZE_INTERNAL_ASSERT(j % panelSize_ == 0 || SO == columnMajor, "Column index not aligned to panel boundary");
-
-            return blast::load<SS>(v_ + elementIndex(i, j));
         }
 
 

--- a/include/blast/math/panel/DynamicPanelMatrix.hpp
+++ b/include/blast/math/panel/DynamicPanelMatrix.hpp
@@ -6,7 +6,7 @@
 
 #include <blast/math/PanelMatrix.hpp>
 #include <blast/math/views/submatrix/BaseTemplate.hpp>
-#include <blast/math/panel/PanelSize.hpp>
+#include <blast/math/simd/SimdSize.hpp>
 #include <blast/system/CacheLine.hpp>
 
 #include <blaze/util/IntegralConstant.h>
@@ -53,17 +53,14 @@ namespace blast
 
 
         explicit DynamicPanelMatrix(size_t m, size_t n)
-        :   m_(m)
-        ,   n_(n)
-        ,   spacing_(
-                SO == columnMajor
-                ? panelSize_ * nextMultiple(n, panelSize_)
-                : nextMultiple(m, panelSize_) * panelSize_
-            )
-        ,   capacity_(nextMultiple(m, panelSize_) * nextMultiple(n, panelSize_))
+        :   m_ {m}
+        ,   n_ {n}
+        ,   spacing_ {SS * (SO == columnMajor ? n : m)}
+        ,   capacity_ {spacing_ * nextMultiple(SO == columnMajor ? m : n, SS)}
+        // Initialize padding elements to 0 to prevent denorms in calculations.
         // Initialize padding elements to 0 to prevent denorms in calculations.
         // Denorms can significantly impair performance, see https://github.com/giaf/blasfeo/issues/103
-        ,   v_(new(std::align_val_t {alignment_}) Type[capacity_] {})
+        ,   v_ {new(std::align_val_t {alignment_}) Type[capacity_] {}}
         {
         }
 
@@ -114,36 +111,7 @@ namespace blast
             , bool SO2 >      // Storage order of the right-hand side matrix
         DynamicPanelMatrix& operator=(Matrix<MT, SO2> const& rhs)
         {
-            // using blaze::assign;
-
-            // using TT = decltype( trans( *this ) );
-            // using CT = decltype( ctrans( *this ) );
-            // using IT = decltype( inv( *this ) );
-
-            // if( (*rhs).rows() != M || (*rhs).columns() != N ) {
-            //     BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to static matrix" );
-            // }
-
-            // if( IsSame_v<MT,TT> && (*rhs).isAliased( this ) ) {
-            //     transpose( typename IsSquare<This>::Type() );
-            // }
-            // else if( IsSame_v<MT,CT> && (*rhs).isAliased( this ) ) {
-            //     ctranspose( typename IsSquare<This>::Type() );
-            // }
-            // else if( !IsSame_v<MT,IT> && (*rhs).canAlias( this ) ) {
-            //     StaticPanelMatrix tmp( *rhs );
-            //     assign( *this, tmp );
-            // }
-            // else {
-            //     if( IsSparseMatrix_v<MT> )
-            //         reset();
-            //     assign( *this, *rhs );
-            // }
-
-            // BLAZE_INTERNAL_ASSERT( isIntact(), "Invariant violation detected" );
-
             assign(*this, *rhs);
-
             return *this;
         }
 
@@ -235,7 +203,7 @@ namespace blast
 
     private:
         static size_t constexpr alignment_ = CACHE_LINE_SIZE;
-        static size_t constexpr panelSize_ = PanelSize_v<Type>;
+        static size_t constexpr SS = SimdSize_v<Type>;
 
         size_t m_;
         size_t n_;
@@ -248,8 +216,8 @@ namespace blast
         size_t elementIndex(size_t i, size_t j) const noexcept
         {
             return SO == columnMajor
-                ? i / panelSize_ * spacing_ + i % panelSize_ + j * panelSize_
-                : j / panelSize_ * spacing_ + j % panelSize_ + i * panelSize_;
+                ? i / SS * spacing_ + i % SS + j * SS
+                : j / SS * spacing_ + j % SS + i * SS;
         }
     };
 }

--- a/include/blast/math/panel/StaticPanelMatrixPointer.hpp
+++ b/include/blast/math/panel/StaticPanelMatrixPointer.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <blast/math/TransposeFlag.hpp>
+#include <blast/math/StorageOrder.hpp>
 #include <blast/math/TypeTraits.hpp>
 #include <blast/math/simd/SimdSize.hpp>
 #include <blast/math/simd/Simd.hpp>
@@ -28,6 +29,7 @@ namespace blast
         static bool constexpr aligned = AF;
         static bool constexpr padded = PF;
         static bool constexpr isStatic = true;
+        static StorageOrder constexpr cachePreferredTraversal = SO == columnMajor ? rowMajor : columnMajor;
 
 
         /**

--- a/include/blast/math/typetraits/IsAligned.hpp
+++ b/include/blast/math/typetraits/IsAligned.hpp
@@ -14,12 +14,15 @@
 
 #pragma once
 
-#include <blast/math/typetraits/IsStatic.hpp>
-#include <blast/math/typetraits/IsAligned.hpp>
-#include <blast/math/typetraits/IsPadded.hpp>
-#include <blast/math/typetraits/ElementType.hpp>
-#include <blast/math/typetraits/StorageOrder.hpp>
-#include <blast/math/typetraits/IsPanelMatrix.hpp>
-#include <blast/math/typetraits/IsPanelSubmatrix.hpp>
-#include <blast/math/typetraits/VectorPointer.hpp>
-#include <blast/math/typetraits/MatrixPointer.hpp>
+#include <blaze/math/typetraits/IsAligned.h>
+
+
+namespace blast
+{
+    template <typename T>
+    struct IsAligned : blaze::IsAligned<T> {};
+
+
+    template <typename T>
+    bool constexpr IsAligned_v = IsAligned<T>::value;
+}

--- a/include/blast/math/typetraits/MatrixPointer.hpp
+++ b/include/blast/math/typetraits/MatrixPointer.hpp
@@ -24,6 +24,7 @@ namespace blast
         trans(p);
         ~p;
         *p;
+        p.cachePreferredTraversal;
 
         // {p.get()} -> std::same_as<T *>;
     };

--- a/include/blast/math/views/submatrix/Panel.hpp
+++ b/include/blast/math/views/submatrix/Panel.hpp
@@ -91,7 +91,7 @@ namespace blast
         ,   j_(j)
         ,   m_(m)
         ,   n_(n)
-        ,   data_(matrix_.ptr(row(), column()))
+        ,   data_(&matrix_(row(), column()))
         {
             if( !Contains_v< TypeList<RSAs...>, Unchecked > )
             {
@@ -204,19 +204,6 @@ namespace blast
         }
 
 
-        template <size_t SS>
-        auto load(size_t i, size_t j) const
-        {
-            if( i >= rows() ) {
-                BLAZE_THROW_OUT_OF_RANGE( "Invalid row access index" );
-            }
-            if( j >= columns() ) {
-                BLAZE_THROW_OUT_OF_RANGE( "Invalid column access index" );
-            }
-            return matrix_.template load<SS>(row() + i, column() + j);
-        }
-
-
         Reference at( size_t i, size_t j )
         {
             if( i >= rows() ) {
@@ -250,18 +237,6 @@ namespace blast
         ConstPointer data() const noexcept
         {
             return data_;
-        }
-
-
-        Pointer ptr(size_t i, size_t j)
-        {
-            return matrix_.ptr(i + row(), j + column());
-        }
-
-
-        ConstPointer ptr(size_t i, size_t j) const
-        {
-            return matrix_.ptr(i + row(), j + column());
         }
 
 

--- a/test/blast/math/dense/MatrixPointerTest.cpp
+++ b/test/blast/math/dense/MatrixPointerTest.cpp
@@ -162,6 +162,24 @@ namespace blast :: testing
     }
 
 
+    TYPED_TEST(MatrixPointerTest, testIsAlignedByDefault)
+    {
+        auto const p = ptr(this->m_);
+        EXPECT_EQ(p.aligned, IsAligned_v<decltype(this->m_)>);
+    }
+
+
+    TYPED_TEST(MatrixPointerTest, testIsAligned)
+    {
+        for (size_t i = 0; i < rows(this->m_); i += this->incI_)
+            for (size_t j = 0; j < columns(this->m_); j += this->incJ_)
+            {
+                auto const p = ptr<TestFixture::isAligned>(this->m_, i, j);
+                EXPECT_EQ(p.aligned, TestFixture::isAligned);
+            }
+    }
+
+
     TYPED_TEST(MatrixPointerTest, testGet)
     {
         for (size_t i = 0; i < rows(this->m_); i += this->incI_)

--- a/test/blast/math/panel/DynamicPanelMatrixTest.cpp
+++ b/test/blast/math/panel/DynamicPanelMatrixTest.cpp
@@ -37,7 +37,7 @@ namespace blast :: testing
     {
         {
             DynamicPanelMatrix<double> m(5, 2);
-            EXPECT_EQ(m.spacing(), 4 * 4);
+            EXPECT_EQ(m.spacing(), 4 * 2);
         }
 
         {
@@ -47,7 +47,7 @@ namespace blast :: testing
 
         {
             DynamicPanelMatrix<double> m(5, 7);
-            EXPECT_EQ(m.spacing(), 4 * 8);
+            EXPECT_EQ(m.spacing(), 4 * 7);
         }
     }
 

--- a/test/blast/math/panel/GemmTest.cpp
+++ b/test/blast/math/panel/GemmTest.cpp
@@ -57,18 +57,11 @@ namespace blast :: testing
                     B = blaze_B;
                     C = blaze_C;
 
-                    // std::cout << "A=\n" << A << std::endl;
-                    // std::cout << "B=\n" << B << std::endl;
-                    // std::cout << "C=\n" << C << std::endl;
-
                     // Do gemm with BLAST
                     gemm_nt(A, B, C, D);
 
                     // Copy the resulting D matrix from BLAST to Blaze
                     blaze_D = D;
-
-                    // Print the result from BLAST
-                    // std::cout << "blaze_D=\n" << blaze_blasfeo_D;
 
                     BLAST_ASSERT_APPROX_EQ(blaze_D, evaluate(blaze_C + blaze_A * trans(blaze_B)), absTol<Real>(), relTol<Real>())
                         << "gemm error at size m,n,k=" << M << "," << N << "," << K;
@@ -78,46 +71,9 @@ namespace blast :: testing
     }
 
 
-    TYPED_TEST_P(PanelGemmTest, testNT_submatrix)
-    {
-        using Real = TypeParam;
-        size_t const M = 8, N = 8, K = 3 * 8;
-
-        // Init Blaze matrices
-        //
-        blaze::DynamicMatrix<Real, blaze::columnMajor> blaze_A(M, K), blaze_B(N, K), blaze_C(M, N), blaze_D(M, N);
-        randomize(blaze_A);
-        randomize(blaze_B);
-        randomize(blaze_C);
-
-        // Init BLAST matrices
-        //
-        StaticPanelMatrix<Real, M, K> A;
-        StaticPanelMatrix<Real, N, K> B;
-        StaticPanelMatrix<Real, M, N> C;
-        StaticPanelMatrix<Real, M, N> D;
-
-        A = blaze_A;
-        B = blaze_B;
-        C = blaze_C;
-
-        // Do gemm with BLAST
-        auto D1 = submatrix(D, 0, 0, M, N);
-        gemm_nt(submatrix(A, 0, 0, M, K), submatrix(B, 0, 0, N, K), submatrix(C, 0, 0, M, N), D1);
-
-        // Copy the resulting D matrix from BLAST to Blaze
-        blaze_D = D;
-
-        // Print the result from BLAST
-        // std::cout << "blaze_D=\n" << blaze_blasfeo_D;
-
-        BLAST_EXPECT_APPROX_EQ(blaze_D, evaluate(blaze_C + blaze_A * trans(blaze_B)), absTol<Real>(), relTol<Real>());
-    }
-
 
     REGISTER_TYPED_TEST_SUITE_P(PanelGemmTest,
-        testNT,
-        testNT_submatrix
+        testNT
     );
 
 

--- a/test/blast/math/views/SubmatrixTest.cpp
+++ b/test/blast/math/views/SubmatrixTest.cpp
@@ -16,6 +16,7 @@ namespace blast :: testing
     {
         StaticPanelMatrix<double, 12, 12, columnMajor> A;
         auto B = submatrix(A, 4, 0, 8, 8);
+        EXPECT_EQ(IsAligned_v<decltype(B)>, false);
     }
 
 
@@ -23,6 +24,7 @@ namespace blast :: testing
     {
         StaticPanelMatrix<double, 12, 12, columnMajor> const A;
         auto B = submatrix(A, 4, 0, 8, 8);
+        EXPECT_EQ(IsAligned_v<decltype(B)>, false);
     }
 
 
@@ -33,6 +35,8 @@ namespace blast :: testing
 
         static_assert(std::is_same_v<decltype(B.ptr(0, 0)), double *>);
         B.ptr(0, 0);
+
+        EXPECT_EQ(IsAligned_v<decltype(B)>, false);
     }
 
 
@@ -43,6 +47,8 @@ namespace blast :: testing
 
         static_assert(std::is_same_v<decltype(B.ptr(0, 0)), double const *>);
         B.ptr(0, 0);
+
+        EXPECT_EQ(IsAligned_v<decltype(B)>, false);
     }
 
 
@@ -74,5 +80,7 @@ namespace blast :: testing
                 ASSERT_EQ(B1(i, j), val);
                 ASSERT_EQ(A(i + B1.row(), j + B1.column()), val);
             }
+
+        EXPECT_EQ(IsAligned_v<decltype(B)>, false);
     }
 }

--- a/test/blast/math/views/SubmatrixTest.cpp
+++ b/test/blast/math/views/SubmatrixTest.cpp
@@ -33,9 +33,7 @@ namespace blast :: testing
         DynamicPanelMatrix<double, columnMajor> A(12, 12);
         auto B = submatrix(A, 4, 0, 8, 8);
 
-        static_assert(std::is_same_v<decltype(B.ptr(0, 0)), double *>);
-        B.ptr(0, 0);
-
+        static_assert(std::is_same_v<decltype(&B(0, 0)), double *>);
         EXPECT_EQ(IsAligned_v<decltype(B)>, false);
     }
 
@@ -45,9 +43,7 @@ namespace blast :: testing
         DynamicPanelMatrix<double, columnMajor> const A(12, 12);
         auto B = submatrix(A, 4, 0, 8, 8);
 
-        static_assert(std::is_same_v<decltype(B.ptr(0, 0)), double const *>);
-        B.ptr(0, 0);
-
+        static_assert(std::is_same_v<decltype(&B(0, 0)), double const *>);
         EXPECT_EQ(IsAligned_v<decltype(B)>, false);
     }
 


### PR DESCRIPTION
Blocked algorithms process matrices block-wise, where block size is chosen based on matrix size, SIMD register size, and the number of available SIMD registers. For example, in matrix-matrix multiplication (`dgemm()`), the resulting matrix is split into non-overlapping blocks (tiles), each of them fitting into a `RegisterMatrix`. The `dgemm()` result is computed for each tile in registers, and then stored to memory. For performance, we want the tile to be as large as the register space allows. But for smaller matrices, and for matrices whose size is not a multiple of tile size, we have to use smaller tiles or partially filled tiles.

Similar logic is employed by other algorithms, e.g. Cholesky decomposition `potrf()`. So we want to separate the logic of splitting a matrix into tiles from the code that processes the tiles. This is what we do in thin pull request.