### PR TITLE
Consistent gemm tests

### DIFF
--- a/bench/analysis/dgemm_performance.py
+++ b/bench/analysis/dgemm_performance.py
@@ -1,3 +1,5 @@
+import matplotlib
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import json
 

--- a/bench/analysis/dgemm_performance_ratio.py
+++ b/bench/analysis/dgemm_performance_ratio.py
@@ -1,3 +1,5 @@
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import json
 

--- a/bench/blas/Gemm.cpp
+++ b/bench/blas/Gemm.cpp
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+#include <bench/Gemm.hpp>
 
-
-#include <benchmark/benchmark.h>
+#include <test/Randomize.hpp>
 
 #include <blaze/Math.h>
 
@@ -28,13 +28,17 @@ namespace blast :: benchmark
         blaze::DynamicMatrix<Real, blaze::columnMajor> C(m, m);
         randomize(C);
 
-        for (auto _ : state)
-            gemm(C, trans(A), B, 1.0, 1.0);
+        Real alpha, beta;
+        randomize(alpha);
+        randomize(beta);
 
-        state.counters["flops"] = Counter(2 * m * m * m, Counter::kIsIterationInvariantRate);
+        for (auto _ : state)
+            gemm(C, trans(A), B, alpha, beta);
+
+        setCounters(state.counters, complexityGemm(m, m, m));
         state.counters["m"] = m;
     }
 
-    BENCHMARK_TEMPLATE(BM_gemm, double)->DenseRange(1, 50);
-    BENCHMARK_TEMPLATE(BM_gemm, float)->DenseRange(1, 50);
+    BENCHMARK_TEMPLATE(BM_gemm, double)->DenseRange(1, BENCHMARK_MAX_GEMM);
+    BENCHMARK_TEMPLATE(BM_gemm, float)->DenseRange(1, BENCHMARK_MAX_GEMM);
 }

--- a/bench/blas/Iamax.cpp
+++ b/bench/blas/Iamax.cpp
@@ -43,7 +43,7 @@ namespace blast :: benchmark
     static void BM_iamax(State& state)
     {
         size_t const N = state.range(0);
-        DynamicVector<Real> x(N);
+        blaze::DynamicVector<Real> x(N);
         randomize(x);
 
         for (auto _ : state)

--- a/bench/blas/Syrk.cpp
+++ b/bench/blas/Syrk.cpp
@@ -5,7 +5,7 @@
 
 
 #include <bench/Benchmark.hpp>
-#include <bench/Complexity.hpp>
+#include <bench/Syrk.hpp>
 
 #include <blaze/Math.h>
 

--- a/bench/blasfeo/Gemm.cpp
+++ b/bench/blasfeo/Gemm.cpp
@@ -7,7 +7,6 @@
 #include <bench/Gemm.hpp>
 
 #include <random>
-#include <memory>
 
 
 namespace blast :: benchmark
@@ -53,7 +52,7 @@ namespace blast :: benchmark
         for (auto _ : state)
             gemm_nt(m, n, k, 1., A, 0, 0, B, 0, 0, 1., C, 0, 0, C, 0, 0);
 
-        state.counters["flops"] = Counter(2 * m * n * k + 3 * m * n, Counter::kIsIterationInvariantRate);
+        setCounters(state.counters, complexityGemm(m, n, k));
         state.counters["m"] = m;
     }
 

--- a/bench/blasfeo/Syrk.cpp
+++ b/bench/blasfeo/Syrk.cpp
@@ -4,10 +4,8 @@
 
 #include <blasfeo/Blasfeo.hpp>
 
-
-
 #include <bench/Benchmark.hpp>
-#include <bench/Complexity.hpp>
+#include <bench/Syrk.hpp>
 
 
 namespace blast :: benchmark

--- a/bench/blast/math/dense/DynamicGemm.cpp
+++ b/bench/blast/math/dense/DynamicGemm.cpp
@@ -4,13 +4,11 @@
 
 #include <blast/math/dense/Gemm.hpp>
 
+#include <bench/Gemm.hpp>
+
 #include <blaze/math/DynamicMatrix.h>
 
-#include <bench/Gemm.hpp>
 #include <test/Randomize.hpp>
-
-#include <random>
-#include <memory>
 
 
 namespace blast :: benchmark
@@ -26,21 +24,24 @@ namespace blast :: benchmark
         DynamicMatrix<Real, columnMajor> B(N, K);
         DynamicMatrix<Real, columnMajor> C(M, N);
         DynamicMatrix<Real, columnMajor> D(M, N);
+        Real alpha, beta;
 
         randomize(A);
         randomize(B);
         randomize(C);
+        randomize(alpha);
+        randomize(beta);
 
         for (auto _ : state)
         {
-            gemm(1., A, trans(B), 1., C, D);
+            gemm(alpha, A, trans(B), beta, C, D);
             DoNotOptimize(A);
             DoNotOptimize(B);
             DoNotOptimize(C);
             DoNotOptimize(D);
         }
 
-        state.counters["flops"] = Counter(2 * M * N * K, Counter::kIsIterationInvariantRate);
+        setCounters(state.counters, complexityGemm(M, N, K));
         state.counters["m"] = M;
     }
 

--- a/bench/blast/math/dense/DynamicSyrk.cpp
+++ b/bench/blast/math/dense/DynamicSyrk.cpp
@@ -7,12 +7,9 @@
 #include <blaze/math/DynamicMatrix.h>
 
 #include <bench/Benchmark.hpp>
-#include <bench/Complexity.hpp>
+#include <bench/Syrk.hpp>
 
 #include <test/Randomize.hpp>
-
-#include <random>
-#include <memory>
 
 
 namespace blast :: benchmark

--- a/bench/blast/math/dense/StaticGemm.cpp
+++ b/bench/blast/math/dense/StaticGemm.cpp
@@ -4,13 +4,11 @@
 
 #include <blast/math/dense/Gemm.hpp>
 
+#include <bench/Gemm.hpp>
+
 #include <blaze/math/StaticMatrix.h>
 
-#include <bench/Gemm.hpp>
 #include <test/Randomize.hpp>
-
-#include <random>
-#include <memory>
 
 
 namespace blast :: benchmark
@@ -22,24 +20,27 @@ namespace blast :: benchmark
         size_t constexpr K = M;
 
         StaticMatrix<Real, M, K, columnMajor> A;
-        StaticMatrix<Real, N, K, columnMajor> B;
+        StaticMatrix<Real, K, N, columnMajor> B;
         StaticMatrix<Real, M, N, columnMajor> C;
         StaticMatrix<Real, M, N, columnMajor> D;
+        Real alpha, beta;
 
         randomize(A);
         randomize(B);
         randomize(C);
+        randomize(alpha);
+        randomize(beta);
 
         for (auto _ : state)
         {
-            gemm(0.5, A, B, 0.1, C, D);
+            gemm(alpha, A, trans(B), beta, C, D);
             DoNotOptimize(A);
             DoNotOptimize(B);
             DoNotOptimize(C);
             DoNotOptimize(D);
         }
 
-        state.counters["flops"] = Counter(2 * M * N * K + 3 * M * N, Counter::kIsIterationInvariantRate);
+        setCounters(state.counters, complexityGemm(M, N, K));
         state.counters["m"] = M;
     }
 

--- a/bench/blast/math/dense/StaticSyrk.cpp
+++ b/bench/blast/math/dense/StaticSyrk.cpp
@@ -7,10 +7,9 @@
 #include <blaze/math/StaticMatrix.h>
 
 #include <bench/Benchmark.hpp>
-#include <bench/Complexity.hpp>
+#include <bench/Syrk.hpp>
 
-#include <random>
-#include <memory>
+#include <test/Randomize.hpp>
 
 
 namespace blast :: benchmark

--- a/bench/blast/math/panel/DynamicGemm.cpp
+++ b/bench/blast/math/panel/DynamicGemm.cpp
@@ -6,10 +6,8 @@
 #include <blast/math/panel/Gemm.hpp>
 
 #include <bench/Gemm.hpp>
-#include <test/Randomize.hpp>
 
-#include <random>
-#include <memory>
+#include <test/Randomize.hpp>
 
 
 namespace blast :: benchmark
@@ -21,25 +19,28 @@ namespace blast :: benchmark
         size_t const N = M;
         size_t const K = M;
 
-        DynamicPanelMatrix<Real> A(M, K);
-        DynamicPanelMatrix<Real> B(N, K);
-        DynamicPanelMatrix<Real> C(M, N);
-        DynamicPanelMatrix<Real> D(M, N);
+        DynamicPanelMatrix<Real, columnMajor> A(M, K);
+        DynamicPanelMatrix<Real, columnMajor> B(N, K);
+        DynamicPanelMatrix<Real, columnMajor> C(M, N);
+        DynamicPanelMatrix<Real, columnMajor> D(M, N);
+        Real alpha, beta;
 
         randomize(A);
         randomize(B);
         randomize(C);
+        randomize(alpha);
+        randomize(beta);
 
         for (auto _ : state)
         {
-            gemm_nt(A, B, C, D);
+            gemm(alpha, A, trans(B), beta, C, D);
             DoNotOptimize(A);
             DoNotOptimize(B);
             DoNotOptimize(C);
             DoNotOptimize(D);
         }
 
-        state.counters["flops"] = Counter(2 * M * N * K, Counter::kIsIterationInvariantRate);
+        setCounters(state.counters, complexityGemm(M, N, K));
         state.counters["m"] = M;
     }
 

--- a/bench/blast/math/panel/StaticGemm.cpp
+++ b/bench/blast/math/panel/StaticGemm.cpp
@@ -6,10 +6,8 @@
 #include <blast/math/panel/Gemm.hpp>
 
 #include <bench/Gemm.hpp>
-#include <test/Randomize.hpp>
 
-#include <random>
-#include <memory>
+#include <test/Randomize.hpp>
 
 
 namespace blast :: benchmark
@@ -20,25 +18,28 @@ namespace blast :: benchmark
         size_t constexpr N = M;
         size_t constexpr K = M;
 
-        StaticPanelMatrix<Real, M, K> A;
-        StaticPanelMatrix<Real, N, K> B;
-        StaticPanelMatrix<Real, M, N> C;
-        StaticPanelMatrix<Real, M, N> D;
+        StaticPanelMatrix<Real, M, K, columnMajor> A;
+        StaticPanelMatrix<Real, N, K, columnMajor> B;
+        StaticPanelMatrix<Real, M, N, columnMajor> C;
+        StaticPanelMatrix<Real, M, N, columnMajor> D;
+        Real alpha, beta;
 
         randomize(A);
         randomize(B);
         randomize(C);
+        randomize(alpha);
+        randomize(beta);
 
         for (auto _ : state)
         {
-            gemm_nt(A, B, C, D);
+            gemm(alpha, A, trans(B), beta, C, D);
             DoNotOptimize(A);
             DoNotOptimize(B);
             DoNotOptimize(C);
             DoNotOptimize(D);
         }
 
-        state.counters["flops"] = Counter(2 * M * N * K, Counter::kIsIterationInvariantRate);
+        setCounters(state.counters, complexityGemm(M, N, K));
         state.counters["m"] = M;
     }
 

--- a/bench/blast/math/simd/Load.cpp
+++ b/bench/blast/math/simd/Load.cpp
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+#include <blast/math/RegisterMatrix.hpp>
 #include <blast/math/DynamicPanelMatrix.hpp>
 #include <blast/math/dense/DynamicMatrixPointer.hpp>
 #include <blast/math/dense/StaticMatrixPointer.hpp>

--- a/bench/blast/math/simd/Store.cpp
+++ b/bench/blast/math/simd/Store.cpp
@@ -5,6 +5,7 @@
 #include <blast/math/DynamicPanelMatrix.hpp>
 #include <blast/math/dense/DynamicMatrixPointer.hpp>
 #include <blast/math/dense/StaticMatrixPointer.hpp>
+#include <blast/math/RegisterMatrix.hpp>
 
 #include <bench/Benchmark.hpp>
 

--- a/bench/blaze/Gemm.cpp
+++ b/bench/blaze/Gemm.cpp
@@ -2,9 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-
-
 #include <bench/Gemm.hpp>
+#include <test/Randomize.hpp>
 
 #include <blaze/Math.h>
 
@@ -23,18 +22,23 @@ namespace blast :: benchmark
         blaze::StaticMatrix<Real, K, N, blaze::columnMajor> B;
         randomize(B);
 
-        blaze::StaticMatrix<Real, M, N, blaze::columnMajor> C;
+        blaze::StaticMatrix<Real, M, N, blaze::columnMajor> C, D;
         randomize(C);
+
+        Real alpha, beta;
+        randomize(alpha);
+        randomize(beta);
 
         for (auto _ : state)
         {
-            C += trans(A) * B;
+            D = alpha * trans(A) * B + beta * C;
             DoNotOptimize(A);
             DoNotOptimize(B);
             DoNotOptimize(C);
+            DoNotOptimize(D);
         }
 
-        state.counters["flops"] = Counter(2 * M * N * K, Counter::kIsIterationInvariantRate);
+        setCounters(state.counters, complexityGemm(M, N, K));
         state.counters["m"] = M;
         state.counters["n"] = N;
         state.counters["k"] = K;
@@ -52,18 +56,23 @@ namespace blast :: benchmark
         blaze::DynamicMatrix<Real, blaze::columnMajor> B(m, m);
         randomize(B);
 
-        blaze::DynamicMatrix<Real, blaze::columnMajor> C(m, m);
+        blaze::DynamicMatrix<Real, blaze::columnMajor> C(m, m), D(m, m);
         randomize(C);
+
+        Real alpha, beta;
+        randomize(alpha);
+        randomize(beta);
 
         for (auto _ : state)
         {
-            C += trans(A) * B;
+            D = alpha * trans(A) * B + beta * C;
             DoNotOptimize(A);
             DoNotOptimize(B);
             DoNotOptimize(C);
+            DoNotOptimize(D);
         }
 
-        state.counters["flops"] = Counter(2 * m * m * m, Counter::kIsIterationInvariantRate);
+        setCounters(state.counters, complexityGemm(m, m, m));
         state.counters["m"] = m;
     }
 
@@ -90,7 +99,7 @@ namespace blast :: benchmark
                 }
         }
 
-        state.counters["flops"] = Counter(2 * m * m * m, Counter::kIsIterationInvariantRate);
+        setCounters(state.counters, complexityGemm(m, m, m));
         state.counters["m"] = m;
     }
 
@@ -123,7 +132,7 @@ namespace blast :: benchmark
                 }
         }
 
-        state.counters["flops"] = Counter(2 * m * m * m, Counter::kIsIterationInvariantRate);
+        setCounters(state.counters, complexityGemm(m, m, m));
         state.counters["m"] = m;
     }
 

--- a/bench/blaze/Syrk.cpp
+++ b/bench/blaze/Syrk.cpp
@@ -2,9 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-
-
-#include <bench/Gemm.hpp>
+#include <bench/Syrk.hpp>
 
 #include <blaze/Math.h>
 
@@ -128,7 +126,7 @@ namespace blast :: benchmark
     // BENCHMARK_STATIC(4, 5);
     // BENCHMARK_STATIC(20, 40);
     // BENCHMARK_STATIC(30, 35);
-#define BOOST_PP_LOCAL_LIMITS (1, BENCHMARK_MAX_GEMM)
+#define BOOST_PP_LOCAL_LIMITS (1, BENCHMARK_MAX_SYRK)
 #define BOOST_PP_LOCAL_MACRO(N) \
     BENCHMARK_STATIC(N, N);
 #include BOOST_PP_LOCAL_ITERATE()

--- a/bench/common/Benchmark.cpp
+++ b/bench/common/Benchmark.cpp
@@ -7,13 +7,6 @@
 
 namespace blast :: benchmark
 {
-    void syrkBenchArguments(internal::Benchmark * b)
-    {
-        for (int i = 1; i <= BENCHMARK_MAX_SYRK; ++i)
-            b->Args({i, i});
-    }
-
-
     void trmmBenchArguments(internal::Benchmark * b)
     {
         b->Args({1, 2})->Args({4, 5})->Args({30, 35})->Args({20, 40});

--- a/bench/common/CMakeLists.txt
+++ b/bench/common/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(benchmark REQUIRED)
 
 add_library(bench-blast-common STATIC
     Benchmark.cpp
+    Syrk.cpp
 )
 
 target_link_libraries(bench-blast-common

--- a/bench/common/Syrk.cpp
+++ b/bench/common/Syrk.cpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2019-2020 Mikhail Katliar All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include <bench/Syrk.hpp>
+
+
+namespace blast :: benchmark
+{
+    void syrkBenchArguments(internal::Benchmark * b)
+    {
+        for (int i = 1; i <= BENCHMARK_MAX_SYRK; ++i)
+            b->Args({i, i});
+    }
+
+
+    Complexity complexitySyrk(std::size_t m, std::size_t k)
+    {
+        return {
+            {"add", m * (m + 1) * k / 2},
+            {"mul", m * (m + 1) * k / 2}
+        };
+    }
+}

--- a/bench/libxsmm/Gemm.cpp
+++ b/bench/libxsmm/Gemm.cpp
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#include <bench/Benchmark.hpp>
+#include <bench/Gemm.hpp>
+
 #include <test/Randomize.hpp>
 
 #include <libxsmm.h>
@@ -21,25 +22,25 @@ namespace blast :: benchmark
         size_t const n = m;
         size_t const k = m;
         std::vector<value_type> a(m * k), b(k * n), c(m * n, 0);
+        randomize(a);
+        randomize(b);
+        randomize(c);
+
+        // libxsmm behaves upredictably with alpha != 1. || beta != 1.
+        Real const alpha = 1., beta = 1.;
 
         /* C/C++ and Fortran interfaces are available */
         using kernel_type = libxsmm_mmfunction<value_type>;
 
         /* generates and dispatches a matrix multiplication kernel (C++ functor) */
-        kernel_type kernel(LIBXSMM_GEMM_FLAG_NONE, m, n, k, 1.0/*alpha*/, 1.0/*beta*/);
+        kernel_type kernel(LIBXSMM_GEMM_FLAG_NONE, m, n, k, alpha, beta);
         assert(kernel);
-
-        for (auto& aa : a)
-            blaze::randomize(aa);
-
-        for (auto& bb : b)
-            blaze::randomize(bb);
 
         /* kernel multiplies and accumulates matrix products: C += Ai * Bi */
         for (auto _ : state)
             kernel(a.data(), b.data(), c.data());
 
-        state.counters["flops"] = Counter(m * n * k, Counter::kIsIterationInvariantRate);
+        setCounters(state.counters, complexityGemm(m, n, k));
         state.counters["m"] = m;
     }
 
@@ -51,32 +52,32 @@ namespace blast :: benchmark
         size_t const n = m;
         size_t const k = m;
         std::vector<Real> a(m * k), b(n * k), c(m * n, 0);
+        randomize(a);
+        randomize(b);
+        randomize(c);
+
+        // libxsmm behaves upredictably with alpha != 1. || beta != 1.
+        Real const alpha = 1., beta = 1.;
 
         /* C/C++ and Fortran interfaces are available */
         using kernel_type = libxsmm_mmfunction<Real>;
 
         /* generates and dispatches a matrix multiplication kernel (C++ functor) */
-        kernel_type kernel(LIBXSMM_GEMM_FLAG_TRANS_B, m, n, k, 1.0/*alpha*/, 1.0/*beta*/);
+        kernel_type kernel(LIBXSMM_GEMM_FLAG_TRANS_B, m, n, k, alpha, beta);
         assert(kernel);
-
-        for (auto& aa : a)
-            blaze::randomize(aa);
-
-        for (auto& bb : b)
-            blaze::randomize(bb);
 
         /* kernel multiplies and accumulates matrix products: C += Ai * Bi */
         for (auto _ : state)
             kernel(a.data(), b.data(), c.data());
 
-        state.counters["flops"] = Counter(2 * m * n * k, Counter::kIsIterationInvariantRate);
+        setCounters(state.counters, complexityGemm(m, n, k));
         state.counters["m"] = m;
     }
 
 
-    BENCHMARK_TEMPLATE(BM_gemm_nn, double)->DenseRange(1, 50);
-    BENCHMARK_TEMPLATE(BM_gemm_nt, double)->DenseRange(1, 50);
+    BENCHMARK_TEMPLATE(BM_gemm_nn, double)->DenseRange(1, BENCHMARK_MAX_GEMM);
+    BENCHMARK_TEMPLATE(BM_gemm_nt, double)->DenseRange(1, BENCHMARK_MAX_GEMM);
 
-    BENCHMARK_TEMPLATE(BM_gemm_nn, float)->DenseRange(1, 50);
-    BENCHMARK_TEMPLATE(BM_gemm_nt, float)->DenseRange(1, 50);
+    BENCHMARK_TEMPLATE(BM_gemm_nn, float)->DenseRange(1, BENCHMARK_MAX_GEMM);
+    BENCHMARK_TEMPLATE(BM_gemm_nt, float)->DenseRange(1, BENCHMARK_MAX_GEMM);
 }

--- a/include/bench/Benchmark.hpp
+++ b/include/bench/Benchmark.hpp
@@ -8,7 +8,6 @@
 
 #include <benchmark/benchmark.h>
 
-#define BENCHMARK_MAX_SYRK 50
 #define BENCHMARK_MAX_POTRF 50
 
 
@@ -16,7 +15,5 @@ namespace blast :: benchmark
 {
     using namespace ::benchmark;
 
-
-    void syrkBenchArguments(internal::Benchmark * b);
     void trmmBenchArguments(internal::Benchmark * b);
 }

--- a/include/bench/Complexity.hpp
+++ b/include/bench/Complexity.hpp
@@ -67,16 +67,6 @@ namespace blast :: benchmark
     }
 
 
-    /// @brief Algorithmic complexity of syrk
-    inline Complexity complexitySyrk(std::size_t m, std::size_t k)
-    {
-        return {
-            {"add", m * (m + 1) * k / 2},
-            {"mul", m * (m + 1) * k / 2}
-        };
-    }
-
-
     template <typename Map>
     void setCounters(Map& counters, Complexity const& c)
     {

--- a/include/bench/Gemm.hpp
+++ b/include/bench/Gemm.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <bench/Benchmark.hpp>
 #include <bench/Complexity.hpp>
 
 #define BENCHMARK_MAX_GEMM 50

--- a/include/bench/Gemm.hpp
+++ b/include/bench/Gemm.hpp
@@ -5,5 +5,19 @@
 #pragma once
 
 #include <bench/Benchmark.hpp>
+#include <bench/Complexity.hpp>
 
 #define BENCHMARK_MAX_GEMM 50
+
+
+namespace blast :: benchmark
+{
+    /// @brief Algorithmic complexity of gemm
+    inline Complexity complexityGemm(std::size_t m, std::size_t n, std::size_t k)
+    {
+        return {
+            {"add", (m * n) * (k + 1)},
+            {"mul", (m * n) * (k + 2)},
+        };
+    }
+}

--- a/include/bench/Syrk.hpp
+++ b/include/bench/Syrk.hpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2019-2020 Mikhail Katliar All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#pragma once
+
+#include <bench/Complexity.hpp>
+
+#define BENCHMARK_MAX_SYRK 20
+
+
+namespace blast :: benchmark
+{
+    void syrkBenchArguments(internal::Benchmark * b);
+
+    /// @brief Algorithmic complexity of syrk
+    Complexity complexitySyrk(std::size_t m, std::size_t k);
+}

--- a/include/blast/math/DynamicPanelMatrix.hpp
+++ b/include/blast/math/DynamicPanelMatrix.hpp
@@ -347,7 +347,7 @@ namespace blaze
         DynamicPanelMatrix<Type, SO> A(n, n);
         randomize(A);
 
-        gemm_nt(A, A, matrix, matrix);
+        gemm(A, trans(A), matrix, matrix);
 
         // TODO: implement it as below after the matrix *= ctrans( matrix ) expression works.
 

--- a/include/blast/math/RegisterMatrix.hpp
+++ b/include/blast/math/RegisterMatrix.hpp
@@ -4,6 +4,6 @@
 
 #pragma once
 
-
 #include <blast/math/register_matrix/RegisterMatrix.hpp>
 #include <blast/math/register_matrix/DynamicRegisterMatrix.hpp>
+#include <blast/math/register_matrix/Gemm.hpp>

--- a/include/blast/math/StaticPanelMatrix.hpp
+++ b/include/blast/math/StaticPanelMatrix.hpp
@@ -333,7 +333,7 @@ namespace blaze
         StaticPanelMatrix<Type, N, N, SO> A;
         randomize(A);
 
-        gemm_nt(A, A, matrix, matrix);
+        gemm(A, trans(A), matrix, matrix);
 
         // TODO: implement it as below after the matrix *= ctrans( matrix ) expression works.
 

--- a/include/blast/math/dense/TrmmBackend.hpp
+++ b/include/blast/math/dense/TrmmBackend.hpp
@@ -7,7 +7,7 @@
 #include <blast/math/RegisterMatrix.hpp>
 #include <blast/math/dense/DynamicMatrixPointer.hpp>
 #include <blast/math/dense/StaticMatrixPointer.hpp>
-#include <blast/system/Tile.hpp>
+#include <blast/math/algorithm/Gemm.hpp>
 
 
 namespace blast

--- a/include/blast/math/expressions/PMatTransExpr.hpp
+++ b/include/blast/math/expressions/PMatTransExpr.hpp
@@ -117,6 +117,28 @@ namespace blast
         }
 
 
+        /**
+         * @brief Pointer to the data
+         *
+         * @return Pointer to matrix data
+         */
+        ElementType * data() noexcept
+        {
+            return pm_.data();
+        }
+
+
+        /**
+         * @brief Constant pointer to the data
+         *
+         * @return Constant pointer to matrix data
+         */
+        ElementType const * data() const noexcept
+        {
+            return pm_.data();
+        }
+
+
         /*!\brief Returns the current number of columns of the matrix.
         //
         // \return The number of columns of the matrix.

--- a/include/blast/math/panel/DynamicPanelMatrixPointer.hpp
+++ b/include/blast/math/panel/DynamicPanelMatrixPointer.hpp
@@ -272,6 +272,6 @@ namespace blast
     requires (!IsStatic_v<MT>) && IsPanelMatrix_v<MT>
     BLAZE_ALWAYS_INLINE auto ptr(PMatTransExpr<MT, SO> const& m, size_t i, size_t j)
     {
-        return trans(ptr(m.operand(), j, i));
+        return trans(ptr<AF>(m.operand(), j, i));
     }
 }

--- a/include/blast/math/panel/Gemm.hpp
+++ b/include/blast/math/panel/Gemm.hpp
@@ -5,105 +5,76 @@
 #pragma once
 
 #include <blast/math/PanelMatrix.hpp>
-#include <blast/math/RegisterMatrix.hpp>
-#include <blast/math/register_matrix/Gemm.hpp>
-#include <blast/math/simd/SimdSize.hpp>
 #include <blast/math/panel/MatrixPointer.hpp>
-
-#include <blaze/util/Exception.h>
-#include <blaze/util/constraints/SameType.h>
+#include <blast/math/algorithm/Gemm.hpp>
+#include <blast/util/Exception.hpp>
 
 
 namespace blast
 {
-    template <typename MT1, typename MT2, typename MT3, typename MT4>
-    BLAZE_ALWAYS_INLINE void gemm_nt(
-        PanelMatrix<MT1, columnMajor> const& A, PanelMatrix<MT2, columnMajor> const& B,
-        PanelMatrix<MT3, columnMajor> const& C, PanelMatrix<MT4, columnMajor>& D)
+    /**
+     * @brief Matrix-matrix multiplication for @a PanelMatrix arguments
+     *
+     * D := alpha*A*B + beta*C
+     *
+     * alpha and beta are scalars, and A, B and C are matrices, with A
+     * an m by k matrix, B a k by n matrix and C an m by n matrix.
+     *
+     * @param alpha the scalar alpha
+     * @param A the matrix A
+     * @param B the matrix B
+     * @param beta the scalar beta
+     * @param C the matrix C
+     * @param D the output matrix D
+     */
+    template <
+        typename ST1, typename MT1, typename MT2, bool SO2,
+        typename ST2, typename MT3, typename MT4
+    >
+    inline void gemm(
+        ST1 alpha,
+        PanelMatrix<MT1, columnMajor> const& A, PanelMatrix<MT2, SO2> const& B,
+        ST2 beta, PanelMatrix<MT3, columnMajor> const& C, PanelMatrix<MT4, columnMajor>& D)
     {
-        using ET = ElementType_t<MT1>;
-
-        BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE(ElementType_t<MT2>, ET);
-        BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE(ElementType_t<MT3>, ET);
-        BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE(ElementType_t<MT4>, ET);
-
-        gemm_nt(ET(1.), ET(1.), *A, *B, *C, *D);
-    }
-
-
-    template <typename ST1, typename ST2, typename MT1, typename MT2, typename MT3, typename MT4>
-    BLAZE_ALWAYS_INLINE void gemm_nt(
-        ST1 alpha, ST2 beta,
-        PanelMatrix<MT1, columnMajor> const& A, PanelMatrix<MT2, columnMajor> const& B,
-        PanelMatrix<MT3, columnMajor> const& C, PanelMatrix<MT4, columnMajor>& D)
-    {
-        using ET = ElementType_t<MT1>;
-        size_t constexpr SS = SimdSize_v<ET>;
-        size_t constexpr TILE_STEP = 4;    // TODO: this is almost arbitrary and needs to be ppoperly determined
-
-        BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE(ElementType_t<MT2>, ET);
-        BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE(ElementType_t<MT3>, ET);
-        BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE(ElementType_t<MT4>, ET);
-
         size_t const M = rows(A);
-        size_t const N = rows(B);
+        size_t const N = columns(B);
         size_t const K = columns(A);
 
-        if (columns(B) != K)
-            BLAZE_THROW_INVALID_ARGUMENT("Matrix sizes do not match");
+        if (rows(B) != K)
+            BLAST_THROW_EXCEPTION(std::invalid_argument {"Matrix sizes do not match"});
 
         if (rows(C) != M || columns(C) != N)
-            BLAZE_THROW_INVALID_ARGUMENT("Matrix sizes do not match");
+            BLAST_THROW_EXCEPTION(std::invalid_argument {"Matrix sizes do not match"});
 
         if (rows(D) != M || columns(D) != N)
-            BLAZE_THROW_INVALID_ARGUMENT("Matrix sizes do not match");
+            BLAST_THROW_EXCEPTION(std::invalid_argument {"Matrix sizes do not match"});
 
-        size_t i = 0;
-
-        // i + 4 * PANEL_SIZE != M is to improve performance in case when the remaining number of rows is 4 * PANEL_SIZE:
-        // it is more efficient to apply 2 * PANEL_SIZE kernel 2 times than 3 * PANEL_SIZE + 1 * PANEL_SIZE kernel.
-        for (; i + 2 * SS < M && i + 4 * SS != M; i += 3 * SS)
-            gemm_nt_backend<3 * SS, TILE_STEP>(M, N, K, i, alpha, ptr(*A), ~trans(ptr(*B)), beta, ptr(*C), ptr(*D));
-
-        for (; i + 1 * SS < M; i += 2 * SS)
-            gemm_nt_backend<2 * SS, TILE_STEP>(M, N, K, i, alpha, ptr(*A), ~trans(ptr(*B)), beta, ptr(*C), ptr(*D));
-
-        for (; i + 0 * SS < M; i += 1 * SS)
-            gemm_nt_backend<1 * SS, TILE_STEP>(M, N, K, i, alpha, ptr(*A), ~trans(ptr(*B)), beta, ptr(*C), ptr(*D));
+        gemm(M, N, K, alpha, ptr(*A), ptr(*B), beta, ptr(*C), ptr(*D));
     }
 
 
+    /**
+     * @brief Matrix-matrix multiplication for @a PanelMatrix arguments
+     *
+     * D := A*B + C
+     *
+     * A, B and C are matrices, with A
+     * an m by k matrix, B a k by n matrix and C an m by n matrix.
+     *
+     * @param A the matrix A
+     * @param B the matrix B
+     * @param C the matrix C
+     * @param D the output matrix D
+     */
     template <
-        size_t KM, size_t KN, typename T,
-        typename MPA, typename MPB, typename MPC, typename MPD
+        typename MT1, typename MT2, bool SO2,
+        typename MT3, typename MT4
     >
-    requires MatrixPointer<MPA, T> && MatrixPointer<MPB, T> && MatrixPointer<MPC, T> && MatrixPointer<MPD, T>
-    BLAZE_ALWAYS_INLINE void gemm_nt_backend(size_t M, size_t N, size_t K, size_t i, T alpha, MPA A, MPB B, T beta, MPC C, MPD D)
+    inline void gemm(
+        PanelMatrix<MT1, columnMajor> const& A, PanelMatrix<MT2, SO2> const& B,
+        PanelMatrix<MT3, columnMajor> const& C, PanelMatrix<MT4, columnMajor>& D)
     {
-        using ET = ElementType_t<MPD>;
-        RegisterMatrix<ET, KM, KN, columnMajor> ker;
-
-        if (i + KM <= M)
-        {
-            size_t j = 0;
-            auto a = A(i, 0);
-
-            for (; j + KN <= N; j += KN)
-                gemm(ker, K, alpha, a, B(0, j), beta, C(i, j), D(i, j));
-
-            if (j < N)
-                gemm(ker, K, alpha, a, B(0, j), beta, C(i, j), D(i, j), KM, N - j);
-        }
-        else
-        {
-            // Use partial save to calculate the bottom of the resulting matrix.
-            size_t j = 0;
-
-            for (; j + KN <= N; j += KN)
-                gemm(ker, K, alpha, A(i, 0), B(0, j), beta, C(i, j), D(i, j), M - i, KN);
-
-            if (j < N)
-                gemm(ker, K, alpha, A(i, 0), B(0, j), beta, C(i, j), D(i, j), M - i, N - j);
-        }
+        using ET = ElementType_t<MT4>;
+        gemm(ET(1.), A, B, ET(1.), C, D);
     }
 }

--- a/include/blast/math/panel/MatrixPointer.hpp
+++ b/include/blast/math/panel/MatrixPointer.hpp
@@ -26,14 +26,14 @@ namespace blast
     template <typename MT, bool SO>
     BLAZE_ALWAYS_INLINE auto ptr(PanelMatrix<MT, SO>& m)
     {
-        return ptr<IsAligned_v<MT>>(m, 0, 0);
+        return ptr<IsAligned_v<MT>>(*m, 0, 0);
     }
 
 
     template <typename MT, bool SO>
     BLAZE_ALWAYS_INLINE auto ptr(PanelMatrix<MT, SO> const& m)
     {
-        return ptr<IsAligned_v<MT>>(m, 0, 0);
+        return ptr<IsAligned_v<MT>>(*m, 0, 0);
     }
 
 
@@ -41,6 +41,6 @@ namespace blast
     requires IsPanelMatrix_v<MT>
     BLAZE_ALWAYS_INLINE auto ptr(blaze::DMatTransExpr<MT, SO> const& m)
     {
-        return ptr<IsAligned_v<MT>>(m, 0, 0);
+        return ptr<IsAligned_v<MT>>(*m, 0, 0);
     }
 }

--- a/include/blast/math/panel/StaticPanelMatrixPointer.hpp
+++ b/include/blast/math/panel/StaticPanelMatrixPointer.hpp
@@ -264,6 +264,6 @@ namespace blast
     requires IsStatic_v<MT> && IsPanelMatrix_v<MT>
     BLAZE_ALWAYS_INLINE auto ptr(PMatTransExpr<MT, SO> const& m, size_t i, size_t j)
     {
-        return trans(ptr(m.operand(), j, i));
+        return trans(ptr<AF>(m.operand(), j, i));
     }
 }

--- a/include/test/Randomize.hpp
+++ b/include/test/Randomize.hpp
@@ -4,16 +4,27 @@
 
 #pragma once
 
-#include <blast/math/StaticPanelMatrix.hpp>
-
+#include <blaze/util/Random.h>
 
 #include <array>
+#include <vector>
 
 
 namespace blast
 {
+    using blaze::randomize;
+
+
     template <typename T, std::size_t N>
     inline void randomize(std::array<T, N>& a)
+    {
+        for (T& v : a)
+            blaze::randomize(v);
+    }
+
+
+    template <typename T>
+    inline void randomize(std::vector<T>& a)
     {
         for (T& v : a)
             blaze::randomize(v);

--- a/test/blast/math/expressions/PMatTransExprTest.cpp
+++ b/test/blast/math/expressions/PMatTransExprTest.cpp
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+#include <blast/math/StaticPanelMatrix.hpp>
 #include <blast/math/DynamicPanelMatrix.hpp>
 #include <blast/math/panel/Potrf.hpp>
 #include <blast/math/panel/Gemm.hpp>

--- a/test/blast/math/panel/GemmTest.cpp
+++ b/test/blast/math/panel/GemmTest.cpp
@@ -58,7 +58,7 @@ namespace blast :: testing
                     C = blaze_C;
 
                     // Do gemm with BLAST
-                    gemm_nt(A, B, C, D);
+                    gemm(A, trans(B), C, D);
 
                     // Copy the resulting D matrix from BLAST to Blaze
                     blaze_D = D;

--- a/test/blast/math/panel/PotrfTest.cpp
+++ b/test/blast/math/panel/PotrfTest.cpp
@@ -48,7 +48,7 @@ namespace blast :: testing
 
             // Check A == L * trans(L)
             A1 = 0.;
-            gemm_nt(L, L, A1, A1);
+            gemm(L, trans(L), A1, A1);
 
             BLAST_EXPECT_APPROX_EQ(A1, A, absTol<Real>(), relTol<Real>()) << "potrf error for size " << M;
         }

--- a/test/blast/math/simd/SimdVecTest.cpp
+++ b/test/blast/math/simd/SimdVecTest.cpp
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#include <blast/math/simd/SimdIndex.hpp>
+#include <blast/math/Simd.hpp>
 
 #include <blaze/Math.h>
 


### PR DESCRIPTION
Made `gemm` tests consistent:
- `D = alpha * op1(A) * op2(B) + beta * C` is used or implementations that support out-of-place `gemm`
- `C = alpha * op1(A) * op2(B) + beta * C` is used or implementations that support in-place `gemm` only
- `op1` and `op2` are chosen as "transpose" or "don't transpose" depending on what we think is fastest for each implementation
- `alpha = 1.` and `beta = 1.` for `libxsmm`, because otherwise it either crashes or returns in 0 time.