### PR TITLE
Run without only aggregates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BENCH_BLAZE = build/bin/bench-blaze
 BENCH_EIGEN = build/bin/bench-eigen
 BENCH_BLAST = build/bin/bench-blast
 BENCH_LIBXSMM = build/bin/bench-libxsmm
-BENCHMARK_OPTIONS = --benchmark_repetitions=5 --benchmark_counters_tabular=true --benchmark_out_format=json --benchmark_report_aggregates_only=true
+BENCHMARK_OPTIONS = --benchmark_repetitions=10 --benchmark_counters_tabular=true --benchmark_out_format=json
 RUN_MATLAB = matlab -nodisplay -nosplash -nodesktop -r
 BENCH_DATA = bench_result/data
 BENCH_IMAGE = bench_result/image

--- a/bench/analysis/dgemm_performance.py
+++ b/bench/analysis/dgemm_performance.py
@@ -3,7 +3,14 @@ import json
 
 
 def filter_aggregate(benchmarks, name):
-    return [b for b in benchmarks if b['aggregate_name'] == name]
+    result = []
+    for b in benchmarks:
+        try:
+            if b['aggregate_name'] == name:
+                result.append(b)
+        except KeyError:
+            continue
+    return result
 
 
 factor = 1e+9 # Giga

--- a/bench/analysis/dgemm_performance_ratio.py
+++ b/bench/analysis/dgemm_performance_ratio.py
@@ -3,8 +3,14 @@ import json
 
 
 def filter_aggregate(benchmarks, name):
-    return [b for b in benchmarks if b['aggregate_name'] == name]
-
+    result = []
+    for b in benchmarks:
+        try:
+            if b['aggregate_name'] == name:
+                result.append(b)
+        except KeyError:
+            continue
+    return result
 
 def load_benchmark(file_name):
     with open(file_name) as f:


### PR DESCRIPTION
The individual runs are needed to do statistical testing.

So we don't want to discard those results.

I changed the Python script to still run with the `--aggregates-only` option.