### PR TITLE
StorageOrder trait refactoring

### DIFF
--- a/include/blast/blaze/math/TypeTraits.hpp
+++ b/include/blast/blaze/math/TypeTraits.hpp
@@ -10,3 +10,4 @@
 #include <blast/blaze/math/typetraits/IsDenseVector.hpp>
 #include <blast/blaze/math/typetraits/IsDenseMatrix.hpp>
 #include <blast/blaze/math/typetraits/Spacing.hpp>
+#include <blast/blaze/math/typetraits/StorageOrder.hpp>

--- a/include/blast/blaze/math/typetraits/StorageOrder.hpp
+++ b/include/blast/blaze/math/typetraits/StorageOrder.hpp
@@ -1,0 +1,29 @@
+// Copyright 2024 Mikhail Katliar. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#pragma once
+
+#include <blast/math/typetraits/StorageOrder.hpp>
+
+#include <blaze/math/typetraits/IsDenseMatrix.h>
+#include <blaze/math/typetraits/StorageOrder.h>
+
+#include <type_traits>
+
+
+namespace blast
+{
+    /**
+     * @brief Specialization for Blaze matrices
+     *
+     * @tparam MT matrix type
+     */
+    template <typename MT>
+    requires blaze::IsDenseMatrix_v<MT>
+    struct StorageOrderHelper<MT>
+    :   std::integral_constant<StorageOrder,
+            blaze::StorageOrder_v<MT> == blaze::columnMajor ? columnMajor : rowMajor
+        >
+    {};
+}

--- a/include/blast/math/algorithm/Gemm.hpp
+++ b/include/blast/math/algorithm/Gemm.hpp
@@ -13,7 +13,6 @@
 
 namespace blast
 {
-
     /**
      * @brief Matrix-matrix multiplication with @a MatrixPointer arguments
      *
@@ -47,7 +46,7 @@ namespace blast
     {
         using ET = std::remove_cv_t<ElementType_t<MPD>>;
 
-        tile<ET, StorageOrder(StorageOrder_v<MPD>)>(
+        tile<ET, StorageOrder_v<MPD>>(
             xsimd::default_arch {},
             D.cachePreferredTraversal,
             M, N,

--- a/include/blast/math/dense/DynamicMatrixPointer.hpp
+++ b/include/blast/math/dense/DynamicMatrixPointer.hpp
@@ -11,6 +11,8 @@
 #include <blast/util/Assert.hpp>
 #include <blast/system/Inline.hpp>
 
+#include <type_traits>
+
 
 namespace blast
 {
@@ -201,7 +203,14 @@ namespace blast
     };
 
 
-    template <bool SO, typename T, bool AF, bool PF>
+    /**
+     * @brief Specialization for @a DynamicMatrixPointer
+     */
+    template <typename T, bool SO, bool AF, bool PF>
+    struct StorageOrderHelper<DynamicMatrixPointer<T, SO, AF, PF>> : std::integral_constant<StorageOrder, StorageOrder(SO)> {};
+
+
+    template <typename T, bool SO, bool AF, bool PF>
     BLAST_ALWAYS_INLINE auto trans(DynamicMatrixPointer<T, SO, AF, PF> const& p) noexcept
     {
         return p.trans();
@@ -220,7 +229,7 @@ namespace blast
     }
 
 
-    template <bool AF, typename MT>
+    template <bool AF, Matrix MT>
     requires (!IsStatic_v<MT>) && IsDenseMatrix_v<MT>
     BLAST_ALWAYS_INLINE DynamicMatrixPointer<ElementType_t<MT> const, StorageOrder_v<MT>, AF, IsPadded_v<MT>>
         ptr(MT const& m, size_t i, size_t j)

--- a/include/blast/math/dense/StaticMatrixPointer.hpp
+++ b/include/blast/math/dense/StaticMatrixPointer.hpp
@@ -12,6 +12,8 @@
 #include <blast/math/TypeTraits.hpp>
 #include <blast/util/Assert.hpp>
 
+#include <type_traits>
+
 
 namespace blast
 {
@@ -190,6 +192,13 @@ namespace blast
 
         T * ptr_;
     };
+
+
+    /**
+     * @brief Specialization for StaticMatrixPointer
+     */
+    template <typename T, size_t S, bool SO, bool AF, bool PF>
+    struct StorageOrderHelper<StaticMatrixPointer<T, S, SO, AF, PF>> : std::integral_constant<StorageOrder, StorageOrder(SO)> {};
 
 
     template <typename T, size_t S, bool SO, bool AF, bool PF>

--- a/include/blast/math/expressions/PMatTransExpr.hpp
+++ b/include/blast/math/expressions/PMatTransExpr.hpp
@@ -255,4 +255,14 @@ namespace blast
      */
     template <typename MT, bool SO>
     struct Spacing<PMatTransExpr<MT, SO>> : Spacing<MT> {};
+
+
+    /**
+     * @brief Specialization for @a PMatTransExpr
+     *
+     * @tparam expression operand type
+     * @tparam SO storage order
+     */
+    template <typename MT, bool SO>
+    struct StorageOrderHelper<PMatTransExpr<MT, SO>> : std::integral_constant<StorageOrder, StorageOrder(SO)> {};
 }

--- a/include/blast/math/expressions/PanelMatrix.hpp
+++ b/include/blast/math/expressions/PanelMatrix.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <blast/math/typetraits/IsPanelMatrix.hpp>
-#include <blast/math/typetraits/ElementType.hpp>
+#include <blast/math/TypeTraits.hpp>
 #include <blast/math/simd/SimdSize.hpp>
 #include <blast/math/simd/SimdMask.hpp>
 #include <blast/math/simd/SimdIndex.hpp>

--- a/include/blast/math/panel/DynamicPanelMatrix.hpp
+++ b/include/blast/math/panel/DynamicPanelMatrix.hpp
@@ -7,6 +7,7 @@
 #include <blast/math/PanelMatrix.hpp>
 #include <blast/math/views/submatrix/BaseTemplate.hpp>
 #include <blast/math/simd/SimdSize.hpp>
+#include <blast/math/TypeTraits.hpp>
 #include <blast/system/CacheLine.hpp>
 
 #include <blaze/util/IntegralConstant.h>
@@ -18,6 +19,7 @@
 #include <blaze/system/Restrict.h>
 
 #include <new>
+#include <type_traits>
 
 
 namespace blast
@@ -177,6 +179,13 @@ namespace blast
                 : j / SS * spacing_ + j % SS + i * SS;
         }
     };
+
+
+    /**
+     * @brief Specialization for @a DynamicPanelMatrix
+     */
+    template <typename T, bool SO>
+    struct StorageOrderHelper<DynamicPanelMatrix<T, SO>> : std::integral_constant<StorageOrder, StorageOrder(SO)> {};
 }
 
 

--- a/include/blast/math/panel/DynamicPanelMatrixPointer.hpp
+++ b/include/blast/math/panel/DynamicPanelMatrixPointer.hpp
@@ -9,6 +9,9 @@
 #include <blast/math/TypeTraits.hpp>
 #include <blast/math/Simd.hpp>
 #include <blast/util/Assert.hpp>
+#include <blast/system/Inline.hpp>
+
+#include <type_traits>
 
 
 namespace blast
@@ -242,7 +245,11 @@ namespace blast
 
 
     template <bool SO, typename T, bool AF, bool PF>
-    BLAZE_ALWAYS_INLINE auto trans(DynamicPanelMatrixPointer<T, SO, AF, PF> const& p) noexcept
+    struct StorageOrderHelper<DynamicPanelMatrixPointer<T, SO, AF, PF>> : std::integral_constant<StorageOrder, StorageOrder(SO)> {};
+
+
+    template <bool SO, typename T, bool AF, bool PF>
+    BLAST_ALWAYS_INLINE auto trans(DynamicPanelMatrixPointer<T, SO, AF, PF> const& p) noexcept
     {
         return p.trans();
     }
@@ -250,7 +257,7 @@ namespace blast
 
     template <bool AF, Matrix MT>
     requires (!IsStatic_v<MT>) && IsPanelMatrix_v<MT>
-    BLAZE_ALWAYS_INLINE auto ptr(MT& m, size_t i, size_t j)
+    BLAST_ALWAYS_INLINE auto ptr(MT& m, size_t i, size_t j)
     {
         return DynamicPanelMatrixPointer<ElementType_t<MT>, StorageOrder_v<MT>, AF, IsPadded_v<MT>>(data(m), spacing(m), i, j);
     }
@@ -258,7 +265,7 @@ namespace blast
 
     template <bool AF, Matrix MT>
     requires (!IsStatic_v<MT>) && IsPanelMatrix_v<MT>
-    BLAZE_ALWAYS_INLINE auto ptr(MT const& m, size_t i, size_t j)
+    BLAST_ALWAYS_INLINE auto ptr(MT const& m, size_t i, size_t j)
     {
         return DynamicPanelMatrixPointer<ElementType_t<MT> const, StorageOrder_v<MT>, AF, IsPadded_v<MT>>(data(m), spacing(m), i, j);
     }

--- a/include/blast/math/panel/StaticPanelMatrix.hpp
+++ b/include/blast/math/panel/StaticPanelMatrix.hpp
@@ -238,6 +238,18 @@ namespace blast
      */
     template <typename Type, size_t M, size_t N, bool SO>
     struct Spacing<StaticPanelMatrix<Type, M, N, SO>> : std::integral_constant<size_t, StaticPanelMatrix<Type, M, N, SO>::spacing()> {};
+
+
+    /**
+     * @brief Specialization for @a StaticPanelMatrix
+     *
+     * @tparam Type element type
+     * @tparam M number of rows
+     * @tparam N number of columns
+     * @tparam SO storage order
+     */
+    template <typename Type, size_t M, size_t N, bool SO>
+    struct StorageOrderHelper<StaticPanelMatrix<Type, M, N, SO>> : std::integral_constant<StorageOrder, StorageOrder(SO)> {};
 }
 
 namespace blaze

--- a/include/blast/math/panel/StaticPanelMatrixPointer.hpp
+++ b/include/blast/math/panel/StaticPanelMatrixPointer.hpp
@@ -9,6 +9,7 @@
 #include <blast/math/TypeTraits.hpp>
 #include <blast/math/Simd.hpp>
 #include <blast/util/Assert.hpp>
+#include <blast/system/Inline.hpp>
 
 
 namespace blast
@@ -235,8 +236,15 @@ namespace blast
     };
 
 
+    /**
+     * @brief Specialization for @a StaticPanelMatrixPointer
+     */
     template <typename T, size_t S, bool SO, bool AF, bool PF>
-    BLAZE_ALWAYS_INLINE auto trans(StaticPanelMatrixPointer<T, S, SO, AF, PF> const& p) noexcept
+    struct StorageOrderHelper<StaticPanelMatrixPointer<T, S, SO, AF, PF>> : std::integral_constant<StorageOrder, StorageOrder(SO)> {};
+
+
+    template <typename T, size_t S, bool SO, bool AF, bool PF>
+    BLAST_ALWAYS_INLINE auto trans(StaticPanelMatrixPointer<T, S, SO, AF, PF> const& p) noexcept
     {
         return p.trans();
     }
@@ -244,7 +252,7 @@ namespace blast
 
     template <bool AF, Matrix MT>
     requires IsStatic_v<MT> && IsPanelMatrix_v<MT>
-    BLAZE_ALWAYS_INLINE auto ptr(MT& m, size_t i, size_t j)
+    BLAST_ALWAYS_INLINE auto ptr(MT& m, size_t i, size_t j)
     {
         return StaticPanelMatrixPointer<ElementType_t<MT>, Spacing_v<MT>, StorageOrder_v<MT>, AF, IsPadded_v<MT>>(data(m), i, j);
     }
@@ -252,7 +260,7 @@ namespace blast
 
     template <bool AF, Matrix MT>
     requires IsStatic_v<MT> && IsPanelMatrix_v<MT>
-    BLAZE_ALWAYS_INLINE auto ptr(MT const& m, size_t i, size_t j)
+    BLAST_ALWAYS_INLINE auto ptr(MT const& m, size_t i, size_t j)
     {
         return StaticPanelMatrixPointer<ElementType_t<MT> const, Spacing_v<MT>, StorageOrder_v<MT>, AF, IsPadded_v<MT>>(data(m), i, j);
     }

--- a/include/blast/math/register_matrix/RegisterMatrix.hpp
+++ b/include/blast/math/register_matrix/RegisterMatrix.hpp
@@ -5,9 +5,7 @@
 #pragma once
 
 #include <blast/math/Simd.hpp>
-#include <blast/math/typetraits/MatrixPointer.hpp>
-#include <blast/math/typetraits/VectorPointer.hpp>
-#include <blast/math/typetraits/Matrix.hpp>
+#include <blast/math/TypeTraits.hpp>
 #include <blast/math/RowColumnVectorPointer.hpp>
 #include <blast/math/Side.hpp>
 #include <blast/math/UpLo.hpp>
@@ -21,6 +19,8 @@
 #include <blaze/util/Exception.h>
 #include <blaze/util/Assert.h>
 #include <blaze/util/StaticAssert.h>
+
+#include <type_traits>
 
 
 namespace blast
@@ -391,6 +391,18 @@ namespace blast
             return v_[i / SS][j][i % SS];
         }
     };
+
+
+    /**
+     * @brief Specialization for @a RegisterMatrix
+     *
+     * @tparam T type of matrix elements
+     * @tparam M number of rows of the matrix. Must be a multiple of SS.
+     * @tparam N number of columns of the matrix.
+     * @tparam SO orientation of SIMD registers.
+     */
+    template <typename T, size_t M, size_t N, bool SO>
+    struct StorageOrderHelper<RegisterMatrix<T, M, N, SO>> : std::integral_constant<StorageOrder, StorageOrder(SO)> {};
 
 
     template <typename Ker>

--- a/include/blast/math/typetraits/StorageOrder.hpp
+++ b/include/blast/math/typetraits/StorageOrder.hpp
@@ -1,23 +1,39 @@
-// Copyright 2023 Mikhail Katliar
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2024 Mikhail Katliar. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 
 #pragma once
 
-#include <blaze/math/TypeTraits.h>
+#include <blast/math/StorageOrder.hpp>
 
 
 namespace blast
 {
-    using blaze::StorageOrder_v;
+    /**
+     * @brief Deduces storage order of a matrix or a matrix pointer type
+     *
+     * NODE: the naming is not consistent here, because we already have @a StorageOrder enum.
+     *
+     * @tparam MT matrix type
+     */
+    template <typename MT>
+    struct StorageOrderHelper;
+
+
+    /**
+     * @brief Specialization for const types
+     *
+     * @tparam MT matrix type
+     */
+    template <typename MT>
+    struct StorageOrderHelper<MT const> : StorageOrderHelper<MT> {};
+
+
+    /**
+     * @brief Shortcut for @a StorageOrderHelper<MT>::value
+     *
+     * @tparam MT matrix type
+     */
+    template <typename MT>
+    StorageOrder constexpr StorageOrder_v = StorageOrderHelper<MT>::value;
 }


### PR DESCRIPTION
Storage order deduction (`blast::StorageOrder_v`) was based on Blaze mechanism. This PR decouples storage order deduction from Blaze and defines storage order traits for the classes which need it.