### PR TITLE
Decouple from Blaze - part 2

### DIFF
--- a/bench/blas/Gemm.cpp
+++ b/bench/blas/Gemm.cpp
@@ -4,7 +4,7 @@
 
 #include <bench/Gemm.hpp>
 
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 #include <blaze/Math.h>
 

--- a/bench/blas/Iamax.cpp
+++ b/bench/blas/Iamax.cpp
@@ -19,7 +19,7 @@
 #include <bench/Benchmark.hpp>
 #include <bench/Iamax.hpp>
 
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 
 namespace blast :: benchmark

--- a/bench/blast/math/dense/DynamicGemm.cpp
+++ b/bench/blast/math/dense/DynamicGemm.cpp
@@ -8,7 +8,7 @@
 
 #include <bench/Gemm.hpp>
 
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 
 namespace blast :: benchmark

--- a/bench/blast/math/dense/DynamicSyrk.cpp
+++ b/bench/blast/math/dense/DynamicSyrk.cpp
@@ -9,7 +9,7 @@
 #include <bench/Benchmark.hpp>
 #include <bench/Syrk.hpp>
 
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 
 namespace blast :: benchmark

--- a/bench/blast/math/dense/StaticGemm.cpp
+++ b/bench/blast/math/dense/StaticGemm.cpp
@@ -8,7 +8,7 @@
 
 #include <bench/Gemm.hpp>
 
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 
 namespace blast :: benchmark

--- a/bench/blast/math/dense/StaticGetrf.cpp
+++ b/bench/blast/math/dense/StaticGetrf.cpp
@@ -9,7 +9,7 @@
 #include <bench/Complexity.hpp>
 #include <bench/Getrf.hpp>
 
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 #include <vector>
 

--- a/bench/blast/math/dense/StaticPotrf.cpp
+++ b/bench/blast/math/dense/StaticPotrf.cpp
@@ -8,7 +8,7 @@
 #include <bench/Benchmark.hpp>
 #include <bench/Complexity.hpp>
 
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 #include <random>
 #include <memory>

--- a/bench/blast/math/dense/StaticSyrk.cpp
+++ b/bench/blast/math/dense/StaticSyrk.cpp
@@ -9,7 +9,7 @@
 #include <bench/Benchmark.hpp>
 #include <bench/Syrk.hpp>
 
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 
 namespace blast :: benchmark

--- a/bench/blast/math/dense/StaticTrmm.cpp
+++ b/bench/blast/math/dense/StaticTrmm.cpp
@@ -7,7 +7,7 @@
 #include <blast/blaze/Math.hpp>
 
 #include <bench/Gemm.hpp>
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 
 namespace blast :: benchmark

--- a/bench/blast/math/panel/DynamicGemm.cpp
+++ b/bench/blast/math/panel/DynamicGemm.cpp
@@ -7,7 +7,7 @@
 
 #include <bench/Gemm.hpp>
 
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 
 namespace blast :: benchmark

--- a/bench/blast/math/panel/DynamicPotrf.cpp
+++ b/bench/blast/math/panel/DynamicPotrf.cpp
@@ -8,7 +8,7 @@
 #include <bench/Benchmark.hpp>
 #include <bench/Complexity.hpp>
 
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 #include <random>
 #include <memory>

--- a/bench/blast/math/panel/StaticGemm.cpp
+++ b/bench/blast/math/panel/StaticGemm.cpp
@@ -9,7 +9,7 @@
 
 #include <bench/Gemm.hpp>
 
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 
 namespace blast :: benchmark

--- a/bench/blast/math/panel/StaticPotrf.cpp
+++ b/bench/blast/math/panel/StaticPotrf.cpp
@@ -8,7 +8,7 @@
 #include <bench/Benchmark.hpp>
 #include <bench/Complexity.hpp>
 
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 #include <random>
 #include <memory>

--- a/bench/blast/math/simd/Ger.cpp
+++ b/bench/blast/math/simd/Ger.cpp
@@ -7,7 +7,7 @@
 
 #include <bench/Benchmark.hpp>
 
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 
 namespace blast :: benchmark

--- a/bench/blast/math/simd/Load.cpp
+++ b/bench/blast/math/simd/Load.cpp
@@ -9,7 +9,7 @@
 
 #include <bench/Benchmark.hpp>
 
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 #include <blaze/Math.h>
 

--- a/bench/blast/math/simd/PartialGemm.cpp
+++ b/bench/blast/math/simd/PartialGemm.cpp
@@ -8,7 +8,7 @@
 
 #include <bench/Benchmark.hpp>
 
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 #include <blaze/math/StaticMatrix.h>
 

--- a/bench/blast/math/simd/PartialLoad.cpp
+++ b/bench/blast/math/simd/PartialLoad.cpp
@@ -8,7 +8,7 @@
 
 #include <bench/Benchmark.hpp>
 
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 #include <blaze/Math.h>
 

--- a/bench/blast/math/simd/PartialStore.cpp
+++ b/bench/blast/math/simd/PartialStore.cpp
@@ -8,7 +8,7 @@
 
 #include <bench/Benchmark.hpp>
 
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 #include <blaze/math/StaticMatrix.h>
 

--- a/bench/blast/math/simd/Potrf.cpp
+++ b/bench/blast/math/simd/Potrf.cpp
@@ -9,7 +9,7 @@
 #include <bench/Benchmark.hpp>
 #include <bench/Complexity.hpp>
 
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 
 namespace blast :: benchmark

--- a/bench/blast/math/simd/Store.cpp
+++ b/bench/blast/math/simd/Store.cpp
@@ -9,7 +9,7 @@
 
 #include <bench/Benchmark.hpp>
 
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 #include <blaze/Math.h>
 

--- a/bench/blast/math/simd/Trmm.cpp
+++ b/bench/blast/math/simd/Trmm.cpp
@@ -7,7 +7,7 @@
 
 #include <bench/Benchmark.hpp>
 
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 #include <blast/blaze/Math.hpp>
 

--- a/bench/blast/math/simd/Trsm.cpp
+++ b/bench/blast/math/simd/Trsm.cpp
@@ -8,7 +8,7 @@
 #include <bench/Benchmark.hpp>
 #include <bench/Trsm.hpp>
 
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 
 namespace blast :: benchmark

--- a/bench/blaze/Gemm.cpp
+++ b/bench/blaze/Gemm.cpp
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 #include <bench/Gemm.hpp>
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 #include <blaze/Math.h>
 

--- a/bench/blaze/StaticTrmm.cpp
+++ b/bench/blaze/StaticTrmm.cpp
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 #include <bench/Gemm.hpp>
-#include <test/Randomize.hpp>
 
 #include <blaze/Math.h>
 

--- a/bench/eigen/Gemm.cpp
+++ b/bench/eigen/Gemm.cpp
@@ -10,7 +10,7 @@
 
 #include <Eigen/Dense>
 
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 #include <bench/Gemm.hpp>
 
@@ -18,7 +18,6 @@
 namespace blast :: benchmark
 {
     using namespace ::benchmark;
-    using blast::testing::randomize;
 
 
     template <typename Real, size_t M>

--- a/bench/eigen/Gemm.cpp
+++ b/bench/eigen/Gemm.cpp
@@ -18,6 +18,7 @@
 namespace blast :: benchmark
 {
     using namespace ::benchmark;
+    using blast::testing::randomize;
 
 
     template <typename Real, size_t M>

--- a/bench/libxsmm/Gemm.cpp
+++ b/bench/libxsmm/Gemm.cpp
@@ -4,7 +4,7 @@
 
 #include <bench/Gemm.hpp>
 
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 #include <libxsmm.h>
 

--- a/include/blast/math/Matrix.hpp
+++ b/include/blast/math/Matrix.hpp
@@ -14,7 +14,6 @@
 
 #include <iosfwd>
 #include <stdexcept>
-#include <random>
 
 
 namespace blast
@@ -48,18 +47,6 @@ namespace blast
     BLAST_ALWAYS_INLINE auto ptr(MT const& m)
     {
         return ptr<IsAligned_v<MT>>(m, 0, 0);
-    }
-	
-	
-    template <Matrix M>
-    inline void randomize(M& m) noexcept
-    {
-        std::mt19937 rng;
-        std::uniform_real_distribution<ElementType_t<M>> dist;
-
-        for (size_t i = 0; i < rows(m); ++i)
-            for (size_t j = 0; j < columns(m); ++j)
-                m(i, j) = dist(rng);
     }
 
 

--- a/include/blast/math/TransposeFlag.hpp
+++ b/include/blast/math/TransposeFlag.hpp
@@ -1,28 +1,21 @@
-// Copyright 2023 Mikhail Katliar
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2023-2024 Mikhail Katliar. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 
 #pragma once
-
-#include <blaze/math/TransposeFlag.h>
 
 
 namespace blast
 {
+    /**
+     * @brief Defines whether a vector is a row or a column
+     *
+     * The bool values match those of @a blaze::TransposeFlag
+     */
     enum TransposeFlag : bool
     {
-        rowVector = blaze::rowVector,
-        columnVector = blaze::columnVector
+        rowVector = true,
+        columnVector = false
     };
 
 

--- a/include/blast/math/TypeTraits.hpp
+++ b/include/blast/math/TypeTraits.hpp
@@ -9,6 +9,7 @@
 #include <blast/math/typetraits/IsPadded.hpp>
 #include <blast/math/typetraits/IsContiguous.hpp>
 #include <blast/math/typetraits/IsStaticallySpaced.hpp>
+#include <blast/math/typetraits/IsView.hpp>
 #include <blast/math/typetraits/ElementType.hpp>
 #include <blast/math/typetraits/StorageOrder.hpp>
 #include <blast/math/typetraits/Spacing.hpp>

--- a/include/blast/math/algorithm/MakePositiveDefinite.hpp
+++ b/include/blast/math/algorithm/MakePositiveDefinite.hpp
@@ -12,7 +12,7 @@
 #include <blast/util/Exception.hpp>
 
 
-namespace blast :: testing
+namespace blast
 {
     /**
      * @brief Setup of a random positive definite @a Matrix.

--- a/include/blast/math/algorithm/Randomize.hpp
+++ b/include/blast/math/algorithm/Randomize.hpp
@@ -11,7 +11,7 @@
 #include <random>
 
 
-namespace blast :: testing
+namespace blast
 {
     namespace detail
     {

--- a/include/blast/math/dense/DynamicMatrix.hpp
+++ b/include/blast/math/dense/DynamicMatrix.hpp
@@ -1,0 +1,190 @@
+// Copyright (c) 2019-2020 Mikhail Katliar All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#pragma once
+
+#include <blast/math/TypeTraits.hpp>
+#include <blast/math/StorageOrder.hpp>
+#include <blast/math/simd/SimdSize.hpp>
+#include <blast/system/CacheLine.hpp>
+#include <blast/system/Restrict.hpp>
+#include <blast/util/NextMultiple.hpp>
+#include <blast/util/Types.hpp>
+
+#include <new>
+#include <stdexcept>
+
+
+namespace blast
+{
+    /// @brief Row/column major matrix with dynamically defined size.
+    ///
+    /// @tparam T element type of the matrix
+    /// @tparam SO storage order of panel elements
+    ///
+    template <typename T, bool SO = columnMajor>
+    class DynamicMatrix
+    {
+    public:
+        using ElementType = T;
+
+
+        explicit DynamicMatrix(size_t m, size_t n)
+        :   m_ {m}
+        ,   n_ {n}
+        ,   spacing_ {nextMultiple(SO == columnMajor ? m : n, SimdSize_v<T>)}
+        // Initialize padding elements to 0 to prevent denorms in calculations.
+        // Denorms can significantly impair performance, see https://github.com/giaf/blasfeo/issues/103
+        ,   v_ {new(std::align_val_t {alignment_}) T[spacing_ * (SO == columnMajor ? n : m)] {}}
+        {
+        }
+
+
+        DynamicMatrix(DynamicMatrix const& rhs)
+        {
+            throw std::logic_error {"Not implemented"};
+        }
+
+
+        DynamicMatrix(DynamicMatrix&& rhs) noexcept
+        {
+            throw std::logic_error {"Not implemented"};
+        }
+
+
+        ~DynamicMatrix()
+        {
+            delete[] v_;
+        }
+
+
+        DynamicMatrix& operator=(T val) noexcept
+        {
+            for (size_t i = 0; i < m_; ++i)
+                for (size_t j = 0; j < n_; ++j)
+                    (*this)(i, j) = val;
+
+            return *this;
+        }
+
+
+        DynamicMatrix& operator=(DynamicMatrix const& val)
+        {
+            throw std::logic_error {"Not implemented"};
+            return *this;
+        }
+
+
+        DynamicMatrix& operator=(DynamicMatrix&& val) noexcept
+        {
+            throw std::logic_error {"Not implemented"};
+            return *this;
+        }
+
+
+        T const& operator()(size_t i, size_t j) const noexcept
+        {
+            return v_[elementIndex(i, j)];
+        }
+
+
+        T& operator()(size_t i, size_t j) noexcept
+        {
+            return v_[elementIndex(i, j)];
+        }
+
+
+        size_t rows() const noexcept
+        {
+            return m_;
+        }
+
+
+        size_t columns() const noexcept
+        {
+            return n_;
+        }
+
+
+        size_t spacing() const noexcept
+        {
+            return spacing_;
+        }
+
+
+        T * data() noexcept
+        {
+            return v_;
+        }
+
+
+        T const * data() const noexcept
+        {
+            return v_;
+        }
+
+
+    private:
+        static size_t constexpr alignment_ = CACHE_LINE_SIZE;
+        static size_t constexpr SS = SimdSize_v<T>;
+
+        size_t m_;
+        size_t n_;
+        size_t spacing_;
+        T * BLAST_RESTRICT v_;
+
+
+        size_t elementIndex(size_t i, size_t j) const noexcept
+        {
+            return SO == columnMajor ? i + j * spacing_ : i * spacing_ + j;
+        }
+    };
+
+
+    template <typename T, bool SO>
+    inline size_t constexpr rows(DynamicMatrix<T, SO> const& m) noexcept
+    {
+        return m.rows();
+    }
+
+
+    template <typename T, bool SO>
+    inline size_t constexpr columns(DynamicMatrix<T, SO> const& m) noexcept
+    {
+        return m.columns();
+    }
+
+
+    template <typename T, bool SO>
+    inline size_t constexpr spacing(DynamicMatrix<T, SO> const& m) noexcept
+    {
+        return m.spacing();
+    }
+
+
+    template <typename T, bool SO>
+    inline constexpr T * data(DynamicMatrix<T, SO>& m) noexcept
+    {
+        return m.data();
+    }
+
+
+    template <typename T, bool SO>
+    inline constexpr T const * data(DynamicMatrix<T, SO> const& m) noexcept
+    {
+        return m.data();
+    }
+
+
+    template <typename T, bool SO>
+    struct IsDenseMatrix<DynamicMatrix<T, SO>> : std::true_type {};
+
+
+    template <typename T, bool SO>
+    struct IsStatic<DynamicMatrix<T, SO>> : std::false_type {};
+
+
+    template <typename T, bool SO>
+    struct StorageOrderHelper<DynamicMatrix<T, SO>> : std::integral_constant<StorageOrder, StorageOrder(SO)> {};
+}

--- a/include/blast/math/dense/DynamicMatrix.hpp
+++ b/include/blast/math/dense/DynamicMatrix.hpp
@@ -125,6 +125,15 @@ namespace blast
         }
 
 
+        /**
+         * @brief Set all matrix elements to 0
+         */
+        void reset() noexcept
+        {
+            std::fill_n(v_, spacing_ * (SO == columnMajor ? n_ : m_), T {});
+        }
+
+
     private:
         static size_t constexpr alignment_ = CACHE_LINE_SIZE;
         static size_t constexpr SS = SimdSize_v<T>;
@@ -174,6 +183,13 @@ namespace blast
     inline constexpr T const * data(DynamicMatrix<T, SO> const& m) noexcept
     {
         return m.data();
+    }
+
+
+    template <typename T, bool SO>
+    inline void reset(DynamicMatrix<T, SO>& m) noexcept
+    {
+        m.reset();
     }
 
 

--- a/include/blast/math/dense/StaticMatrix.hpp
+++ b/include/blast/math/dense/StaticMatrix.hpp
@@ -138,6 +138,15 @@ namespace blast
         }
 
 
+        /**
+         * @brief Set all matrix elements to 0
+         */
+        void reset() noexcept
+        {
+            std::fill_n(v_, capacity_, T {});
+        }
+
+
     private:
         static size_t constexpr spacing_ = nextMultiple(SO == columnMajor ? M : N, SimdSize_v<T>);
         static size_t constexpr capacity_ = spacing_ * (SO == columnMajor ? N : M);
@@ -181,6 +190,13 @@ namespace blast
     inline constexpr T const * data(StaticMatrix<T, M, N, SO> const& m) noexcept
     {
         return m.data();
+    }
+
+
+    template <typename T, size_t M, size_t N, bool SO>
+    inline void reset(StaticMatrix<T, M, N, SO>& m) noexcept
+    {
+        m.reset();
     }
 
 

--- a/include/blast/math/expressions/MatTransExpr.hpp
+++ b/include/blast/math/expressions/MatTransExpr.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <blast/math/TypeTraits.hpp>
+#include <blast/util/Types.hpp>
 
 #include <type_traits>
 #include <cassert>
@@ -19,14 +20,14 @@ namespace blast
      *
      */
     template <Matrix MT>
-    class TransExpr
+    class MatTransExpr
     {
     public:
         using ElementType = ElementType_t<MT>;
         using Operand = MT const;
 
-        explicit TransExpr(MT const& pm) noexcept
-        :   m_ {pm}
+        explicit MatTransExpr(MT const& matrix) noexcept
+        :   m_ {matrix}
         {}
 
 
@@ -49,11 +50,11 @@ namespace blast
         /**
          * @brief Number of rows
          *
-         * @param e transpose expression
+         * @param e matrix transpose expression
          *
          * @return The number of rows of the transpose expression.
          */
-        friend size_t rows(TransExpr const& e) noexcept
+        friend size_t rows(MatTransExpr const& e) noexcept
         {
             return columns(e.m_);
         }
@@ -62,11 +63,11 @@ namespace blast
         /**
          * @brief Number of columns
          *
-         * @param e transpose expression
+         * @param e matrix transpose expression
          *
          * @return The number of columns of the transpose expression.
          */
-        friend size_t columns(TransExpr const& e) noexcept
+        friend size_t columns(MatTransExpr const& e) noexcept
         {
             return rows(e.m_);
         }
@@ -75,33 +76,39 @@ namespace blast
         /**
          * @brief Pointer to the data
          *
+         * @param e matrix transpose expression
+         *
          * @return Pointer to matrix data
          */
-        ElementType * data() noexcept
+        friend ElementType * data(MatTransExpr& e) noexcept
         {
-            return m_.data();
+            return data(e.m_);
         }
 
 
         /**
          * @brief Constant pointer to the data
          *
+         * @param e matrix transpose expression
+         *
          * @return Constant pointer to matrix data
          */
-        ElementType const * data() const noexcept
+        friend ElementType const * data(MatTransExpr const& e) noexcept
         {
-            return m_.data();
+            return data(e.m_);
         }
 
 
         /**
          * @brief Returns the spacing of the underlying matrix storage.
          *
+         * @param e matrix transpose expression
+         *
          * @return The spacing of the underlying matrix storage.
          */
-        size_t spacing() const noexcept
+        friend size_t spacing(MatTransExpr const& e) noexcept
         {
-            return m_.spacing();
+            return spacing(e.m_);
         }
 
 
@@ -116,7 +123,7 @@ namespace blast
         }
 
     private:
-        Operand m_;
+        Operand& m_;
     };
 
 
@@ -132,7 +139,7 @@ namespace blast
     template <Matrix MT>
     inline auto trans(MT const& m)
     {
-        return TransExpr<MT> {m};
+        return MatTransExpr<MT> {m};
     }
 
 
@@ -146,35 +153,53 @@ namespace blast
      * @return the operand of the transposition expression
      */
     template <typename MT>
-    inline decltype(auto) trans(TransExpr<MT> const& e)
+    inline decltype(auto) trans(MatTransExpr<MT> const& e)
     {
         return e.operand();
     }
 
 
     /**
-     * @brief Specialization for @a TransExpr
+     * @brief Specialization for @a MatTransExpr
      *
      * @tparam MT expression operand type
      */
     template <typename MT>
-    struct IsStatic<TransExpr<MT>> : IsStatic<MT> {};
+    struct IsAligned<MatTransExpr<MT>> : IsAligned<MT> {};
 
 
     /**
-     * @brief Specialization for @a TransExpr
+     * @brief Specialization for @a MatTransExpr
      *
      * @tparam MT expression operand type
      */
     template <typename MT>
-    struct Spacing<TransExpr<MT>> : Spacing<MT> {};
+    struct IsStatic<MatTransExpr<MT>> : IsStatic<MT> {};
 
 
     /**
-     * @brief Specialization for @a TransExpr
+     * @brief Specialization for @a MatTransExpr
      *
      * @tparam MT expression operand type
      */
     template <typename MT>
-    struct StorageOrderHelper<TransExpr<MT>> : std::integral_constant<StorageOrder, !StorageOrder_v<MT>> {};
+    struct IsDenseMatrix<MatTransExpr<MT>> : IsDenseMatrix<MT> {};
+
+
+    /**
+     * @brief Specialization for @a MatTransExpr
+     *
+     * @tparam MT expression operand type
+     */
+    template <typename MT>
+    struct Spacing<MatTransExpr<MT>> : Spacing<MT> {};
+
+
+    /**
+     * @brief Specialization for @a MatTransExpr
+     *
+     * @tparam MT expression operand type
+     */
+    template <typename MT>
+    struct StorageOrderHelper<MatTransExpr<MT>> : std::integral_constant<StorageOrder, !StorageOrder_v<MT>> {};
 }

--- a/include/blast/math/expressions/TransExpr.hpp
+++ b/include/blast/math/expressions/TransExpr.hpp
@@ -1,0 +1,180 @@
+// Copyright (c) 2019-2020 Mikhail Katliar All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#pragma once
+
+#include <blast/math/TypeTraits.hpp>
+
+#include <type_traits>
+#include <cassert>
+
+
+namespace blast
+{
+    /**
+     * @brief Expression object for matrix transpositions
+     *
+     * @tparam MT type of the matrix being transposed
+     *
+     */
+    template <Matrix MT>
+    class TransExpr
+    {
+    public:
+        using ElementType = ElementType_t<MT>;
+        using Operand = MT const;
+
+        explicit TransExpr(MT const& pm) noexcept
+        :   m_ {pm}
+        {}
+
+
+        /**
+         * @brief 2D-access to the matrix elements.
+         *
+         * @param i Access index for the row. The index has to be in the range \f$[0..M-1]\f$.
+         * @param j Access index for the column. The index has to be in the range \f$[0..N-1]\f$.
+         *
+         * @return The resulting value.
+         */
+        ElementType operator()(size_t i, size_t j) const noexcept
+        {
+            assert(i < columns(m_));
+            assert(j < rows(m_));
+            return m_(j, i);
+        }
+
+
+        /**
+         * @brief Number of rows
+         *
+         * @param e transpose expression
+         *
+         * @return The number of rows of the transpose expression.
+         */
+        friend size_t rows(TransExpr const& e) noexcept
+        {
+            return columns(e.m_);
+        }
+
+
+        /**
+         * @brief Number of columns
+         *
+         * @param e transpose expression
+         *
+         * @return The number of columns of the transpose expression.
+         */
+        friend size_t columns(TransExpr const& e) noexcept
+        {
+            return rows(e.m_);
+        }
+
+
+        /**
+         * @brief Pointer to the data
+         *
+         * @return Pointer to matrix data
+         */
+        ElementType * data() noexcept
+        {
+            return m_.data();
+        }
+
+
+        /**
+         * @brief Constant pointer to the data
+         *
+         * @return Constant pointer to matrix data
+         */
+        ElementType const * data() const noexcept
+        {
+            return m_.data();
+        }
+
+
+        /**
+         * @brief Returns the spacing of the underlying matrix storage.
+         *
+         * @return The spacing of the underlying matrix storage.
+         */
+        size_t spacing() const noexcept
+        {
+            return m_.spacing();
+        }
+
+
+        /**
+         * @brief Returns the matrix operand.
+         *
+         * @return The matrix operand.
+         */
+        Operand const& operand() const noexcept
+        {
+            return m_;
+        }
+
+    private:
+        Operand m_;
+    };
+
+
+    /**
+     * @brief Transpose of a matrix
+     *
+     * @tparam MT matrix type
+     *
+     * @param m matrix
+     *
+     * @return expression representing the transposition of the matrix
+     */
+    template <Matrix MT>
+    inline auto trans(MT const& m)
+    {
+        return TransExpr<MT> {m};
+    }
+
+
+    /**
+     * @brief Transpose of a transpose
+     *
+     * @tparam MT matrix type
+     *
+     * @param e matrix transposition expression
+     *
+     * @return the operand of the transposition expression
+     */
+    template <typename MT>
+    inline decltype(auto) trans(TransExpr<MT> const& e)
+    {
+        return e.operand();
+    }
+
+
+    /**
+     * @brief Specialization for @a TransExpr
+     *
+     * @tparam MT expression operand type
+     */
+    template <typename MT>
+    struct IsStatic<TransExpr<MT>> : IsStatic<MT> {};
+
+
+    /**
+     * @brief Specialization for @a TransExpr
+     *
+     * @tparam MT expression operand type
+     */
+    template <typename MT>
+    struct Spacing<TransExpr<MT>> : Spacing<MT> {};
+
+
+    /**
+     * @brief Specialization for @a TransExpr
+     *
+     * @tparam MT expression operand type
+     */
+    template <typename MT>
+    struct StorageOrderHelper<TransExpr<MT>> : std::integral_constant<StorageOrder, !StorageOrder_v<MT>> {};
+}

--- a/include/blast/math/reference/Gemm.hpp
+++ b/include/blast/math/reference/Gemm.hpp
@@ -1,0 +1,93 @@
+// Copyright (c) 2019-2020 Mikhail Katliar All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#pragma once
+
+#include <blast/math/Matrix.hpp>
+#include <blast/util/Exception.hpp>
+
+
+namespace blast :: reference
+{
+    /**
+     * @brief Reference implementation of general matrix-matrix multiplication with @a MatrixPointer arguments
+     *
+     * D := alpha*A*B + beta*C
+     *
+     * alpha and beta are scalars, and A, B and C are matrices, with A
+     * an m by k matrix, B a k by n matrix and C an m by n matrix.
+     *
+     * @tparam ST1 scalar type for @a alpha
+     * @tparam MPA matrix pointer type for @a A
+     * @tparam MPB matrix pointer type for @a B
+     * @tparam ST2 scalar type for @a beta
+     * @tparam MPC matrix pointer type for @a C
+     * @tparam MPD matrix pointer type for @a D
+     *
+     * @param M the number of rows of the matrices A, C, and D.
+     * @param N the number of columns of the matrices B and C.
+     * @param K the number of columns of the matrix A and the number of rows of the matrix B.
+     * @param alpha the scalar alpha
+     * @param A the matrix A
+     * @param B the matrix B
+     * @param beta the scalar beta
+     * @param C the matrix C
+     * @param D the output matrix D
+     */
+    template <
+        typename ST1, MatrixPointer MPA, MatrixPointer MPB,
+        typename ST2, MatrixPointer MPC, MatrixPointer MPD
+    >
+    inline void gemm(size_t M, size_t N, size_t K, ST1 alpha, MPA A, MPB B, ST2 beta, MPC C, MPD D)
+    {
+        using ET = ElementType_t<MPD>;
+
+        for (size_t i = 0; i < M; ++i)
+        {
+            for (size_t j = 0; j < N; ++j)
+            {
+                ET v {};
+                for (size_t k = 0; k < K; ++k)
+                    v += *(~A)(i, k) * *(~B)(k, j);
+
+                *(~D)(i, j) = alpha * v + beta * *(~C)(i, j);
+            }
+        }
+    }
+
+
+    /**
+     * @brief Reference implementation of general matrix-matrix multiplication for generic matrix arguments
+     *
+     * D := alpha*A*B + beta*C
+     *
+     * alpha and beta are scalars, and A, B and C are matrices, with A
+     * an m by k matrix, B a k by n matrix and C an m by n matrix.
+     *
+     * @param alpha the scalar alpha
+     * @param A the matrix A
+     * @param B the matrix B
+     * @param beta the scalar beta
+     * @param C the matrix C
+     * @param D the output matrix D
+     */
+    template <typename ST1, Matrix MT1, Matrix MT2, typename ST2, Matrix MT3, Matrix MT4>
+    inline void gemm(ST1 alpha, MT1 const& A, MT2 const& B, ST2 beta, MT3 const& C, MT4& D)
+    {
+        size_t const M = rows(A);
+        size_t const N = columns(B);
+        size_t const K = columns(A);
+
+        if (rows(B) != K)
+            BLAST_THROW_EXCEPTION(std::invalid_argument {"Matrix sizes do not match"});
+
+        if (rows(C) != M || columns(C) != N)
+            BLAST_THROW_EXCEPTION(std::invalid_argument {"Matrix sizes do not match"});
+
+        if (rows(D) != M || columns(D) != N)
+            BLAST_THROW_EXCEPTION(std::invalid_argument {"Matrix sizes do not match"});
+
+        gemm(M, N, K, alpha, ptr(A), ptr(B), beta, ptr(C), ptr(D));
+    }
+}

--- a/include/blast/math/reference/Ger.hpp
+++ b/include/blast/math/reference/Ger.hpp
@@ -3,8 +3,7 @@
 // license that can be found in the LICENSE file.
 #pragma once
 
-#include <blast/math/typetraits/MatrixPointer.hpp>
-#include <blast/math/typetraits/VectorPointer.hpp>
+#include <blast/math/TypeTraits.hpp>
 #include <blast/util/Types.hpp>
 
 
@@ -13,13 +12,14 @@ namespace blast :: reference
     /**
      * @brief Reference implementation of rank-1 update with multiplier
      *
-     * a(i, j) += alpha * x(i) * y(j)
+     * b(i, j) = a(i, j) + alpha * x(i) * y(j)
      * for i=0...m-1, j=n-1
      *
      * @tparam Real real number type
      * @tparam VPX vector pointer type for the column vector @a x
      * @tparam VPY vector pointer type for the row vector @a y
-     * @tparam MPA
+     * @tparam MPA matrix pointer type for the matrix @a a
+     * @tparam MPB matrix pointer type for the matrix @a b
      *
      * @param m number of rows in the matrix
      * @param n number of columns in the matrix
@@ -29,12 +29,13 @@ namespace blast :: reference
      * @param a matrix to perform update on
      *
      */
-    template <typename Real, typename VPX, typename VPY, typename MPA>
-    requires VectorPointer<VPX, Real> && VectorPointer<VPY, Real> && MatrixPointer<MPA, Real>
-    inline void ger(size_t m, size_t n, Real alpha, VPX x, VPY y, MPA a)
+    template <typename Real, typename VPX, typename VPY, typename MPA, typename MPB>
+    requires VectorPointer<VPX, Real> && VectorPointer<VPY, Real> && MatrixPointer<MPA, Real> && MatrixPointer<MPB, Real>
+        // && VPX::transposeFlag == columnVector && VPY::transposeFlag == rowVector
+    inline void ger(size_t m, size_t n, Real alpha, VPX x, VPY y, MPA a, MPB b)
     {
         for (size_t i = 0; i < m; ++i)
             for (size_t j = 0; j < n; ++j)
-                *(~a)(i, j) += alpha * *(~x)(i) * *(~y)(j);
+                *(~b)(i, j) = *(~a)(i, j) + alpha * *(~x)(i) * *(~y)(j);
     }
 }

--- a/include/blast/math/typetraits/IsStatic.hpp
+++ b/include/blast/math/typetraits/IsStatic.hpp
@@ -17,6 +17,15 @@ namespace blast
 
 
     /**
+     * @brief Specialization for const types
+     *
+     * @tparam T matrix or vector type
+     */
+    template <typename T>
+    struct IsStatic<T const> : IsStatic<T> {};
+
+
+    /**
      * @brief Shortcut for @a IsStatic<T>::value
      *
      * @tparam T matrix or vector type

--- a/include/blast/math/typetraits/IsView.hpp
+++ b/include/blast/math/typetraits/IsView.hpp
@@ -1,0 +1,28 @@
+// Copyright 2024 Mikhail Katliar. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#pragma once
+
+#include <type_traits>
+
+
+namespace blast
+{
+    /**
+     * @brief Tests if the given matrix or vector type is a view.
+     *
+     * @tparam T matrix or vector type
+     */
+    template <typename T>
+    struct IsView : std::integral_constant<bool, false> {};
+
+
+    /**
+     * @brief Shortcut for @a IsView<T>::value
+     *
+     * @tparam T matrix or vector type
+     */
+    template <typename T>
+    bool constexpr IsView_v = IsView<T>::value;
+}

--- a/include/blast/math/typetraits/VectorPointer.hpp
+++ b/include/blast/math/typetraits/VectorPointer.hpp
@@ -23,5 +23,7 @@ namespace blast
         *p;
 
         // {p.get()} -> std::same_as<T *>;
+
+        P::transposeFlag;
     };
 }

--- a/include/blast/math/views/Submatrix.hpp
+++ b/include/blast/math/views/Submatrix.hpp
@@ -118,9 +118,9 @@ namespace blast
         }
 
 
-        size_t spacing() const noexcept
+        friend size_t spacing(Submatrix const& m) noexcept
         {
-            return matrix_.spacing();
+            return spacing(m.matrix_);
         }
 
 
@@ -142,20 +142,20 @@ namespace blast
         }
 
 
-        Pointer data() noexcept
+        friend Pointer data(Submatrix& m) noexcept
         {
-            return data_;
+            return m.data_;
         }
 
 
-        ConstPointer data() const noexcept
+        friend ConstPointer data(Submatrix const& m) noexcept
         {
-            return data_;
+            return m.data_;
         }
 
 
     private:
-        ViewedType matrix_;        //!< The matrix containing the submatrix.
+        ViewedType& matrix_;        //!< The matrix containing the submatrix.
         size_t const i_;
         size_t const j_;
         size_t const m_;
@@ -174,6 +174,41 @@ namespace blast
 
 
     /**
+     * @brief Specialization for @a Submatrix class
+     */
+    template <typename MT, AlignmentFlag AF>
+    struct IsStatic<Submatrix<MT, AF>> : IsStatic<MT> {};
+
+
+    /**
+     * @brief Specialization for @a Submatrix class
+     */
+    template <typename MT, AlignmentFlag AF>
+    struct IsDenseMatrix<Submatrix<MT, AF>> : IsDenseMatrix<MT> {};
+
+
+    /**
+     * @brief Specialization for @a Submatrix class
+     */
+    template <typename MT, AlignmentFlag AF>
+    struct IsView<Submatrix<MT, AF>> : std::integral_constant<bool, true> {};
+
+
+    /**
+     * @brief Specialization for @a Submatrix class
+     */
+    template <typename MT, AlignmentFlag AF>
+    struct Spacing<Submatrix<MT, AF>> : Spacing<MT> {};
+
+
+    /**
+     * @brief Specialization for @a Submatrix class
+     */
+    template <typename MT, AlignmentFlag AF>
+    struct StorageOrderHelper<Submatrix<MT, AF>> : StorageOrderHelper<MT> {};
+
+
+    /**
      * @brief Submatrix of a matrix
      *
      * @tparam AF alignment flag of the resulting submatrix
@@ -187,7 +222,7 @@ namespace blast
      *
      * @return submatrix of @a matrix
      */
-    template <AlignmentFlag AF, Matrix MT>
+    template <AlignmentFlag AF, typename MT>
     inline decltype(auto) submatrix(MT& matrix, size_t row, size_t column, size_t m, size_t n)
     {
         return Submatrix<MT, AF> {matrix, row, column, m, n};
@@ -209,7 +244,7 @@ namespace blast
      *
      * @return submatrix of @a matrix
      */
-    template <AlignmentFlag AF, Matrix MT, AlignmentFlag AF1>
+    template <AlignmentFlag AF, typename MT, AlignmentFlag AF1>
     inline decltype(auto) submatrix(Submatrix<MT, AF1> const& matrix, size_t row, size_t column, size_t m, size_t n)
     {
         return Submatrix<MT const, AF> {matrix.operand(), matrix.row() + row, matrix.column() + column, m, n};
@@ -231,9 +266,23 @@ namespace blast
      *
      * @return submatrix of @a matrix
      */
-    template <AlignmentFlag AF, Matrix MT, AlignmentFlag AF1>
+    template <AlignmentFlag AF, typename MT, AlignmentFlag AF1>
     inline decltype(auto) submatrix(Submatrix<MT, AF1>& matrix, size_t row, size_t column, size_t m, size_t n)
     {
-        return PanelSubmatrix<MT, AF> {matrix.operand(), matrix.row() + row, matrix.column() + column, m, n};
+        return Submatrix<MT, AF> {matrix.operand(), matrix.row() + row, matrix.column() + column, m, n};
+    }
+
+
+    /**
+     * @brief Set all elements of a submatrix to their default value (0).
+     *
+     * @param matrix submatrix to set to 0.
+     */
+    template <typename MT, AlignmentFlag AF>
+    inline void reset(Submatrix<MT, AF>& matrix) noexcept
+    {
+        for (size_t i = 0; i < rows(matrix); ++i)
+            for (size_t j = 0; j < columns(matrix); ++j)
+                matrix(i, j) = ElementType_t<MT> {};
     }
 }

--- a/include/blast/math/views/Submatrix.hpp
+++ b/include/blast/math/views/Submatrix.hpp
@@ -6,3 +6,234 @@
 
 #include <blast/math/views/submatrix/BaseTemplate.hpp>
 #include <blast/math/views/submatrix/Panel.hpp>
+#include <blast/math/TypeTraits.hpp>
+
+#include <type_traits>
+
+
+namespace blast
+{
+    /**
+     * @brief Submatrix view of a matrix
+     *
+     * @tparam MT viewed matrix type
+     * @tparam AF whether the submatrix lop left element is aligned
+     */
+    template <Matrix MT, AlignmentFlag AF>
+    class Submatrix
+    {
+    public:
+        using ViewedType = MT;
+        using ElementType = ElementType_t<MT>;
+
+        //! Reference to a constant submatrix value.
+        using ConstReference = ElementType const&;
+
+        //! Reference to a non-constant submatrix value.
+        using Reference = std::conditional_t<IsConst_v<MT>, ConstReference, ElementType&>;
+
+        //! Pointer to a constant submatrix value.
+        using ConstPointer = ElementType const *;
+
+        //! Pointer to a non-constant submatrix value.
+        using Pointer = std::conditional_t<IsConst_v<MT>, ConstPointer, ElementType *>;
+
+
+        /**
+         * @brief Constructor
+         *
+         * @param i top row index of the submatrix
+         * @param j left column index of the submatrix
+         * @param m number of rows of the submatrix
+         * @param n number of columns of the submatrix
+         */
+        explicit inline constexpr Submatrix(MT& matrix, size_t i, size_t j, size_t m, size_t n)
+        :   matrix_ {matrix}
+        ,   i_ {i}
+        ,   j_ {j}
+        ,   m_ {m}
+        ,   n_ {n}
+        ,   data_ {&matrix_(i_, j_)}
+        {
+            BLAST_USER_ASSERT(i_ + m_ <= rows(matrix_), "Invalid submatrix specification");
+            BLAST_USER_ASSERT(j_ + n_ <= columns(matrix_), "Invalid submatrix specification");
+        }
+
+
+        Submatrix(Submatrix const&) = default;
+
+
+        /**
+         * @brief Matrix assignment
+         *
+         * Copies elements from the right-hand side expression
+         *
+         * @tparam MT2 type of right-hand side matrix
+         *
+         * @param rhs
+         *
+         * @return reference to *this
+         */
+        template <Matrix MT2>
+        Submatrix& operator=(MT2 const& rhs)
+        {
+            assign(*this, rhs);
+            return *this;
+        }
+
+
+        size_t constexpr row() const noexcept
+        {
+            return i_;
+        };
+
+
+        size_t constexpr column() const noexcept
+        {
+            return j_;
+        };
+
+
+        friend size_t constexpr rows(Submatrix const& m) noexcept
+        {
+            return m.m_;
+        };
+
+
+        friend size_t constexpr columns(Submatrix const& m) noexcept
+        {
+            return m.n_;
+        };
+
+
+        MT& operand() noexcept
+        {
+            return matrix_;
+        }
+
+
+        const MT& operand() const noexcept
+        {
+            return matrix_;
+        }
+
+
+        size_t spacing() const noexcept
+        {
+            return matrix_.spacing();
+        }
+
+
+        Reference operator()(size_t i, size_t j) noexcept
+        {
+            BLAST_USER_ASSERT(i < m_, "Invalid row access index");
+            BLAST_USER_ASSERT(j < n_, "Invalid column access index");
+
+            return matrix_(i_ + i, j_ + j);
+        }
+
+
+        ConstReference operator()( size_t i, size_t j ) const
+        {
+            BLAST_USER_ASSERT(i < m_, "Invalid row access index");
+            BLAST_USER_ASSERT(j < n_, "Invalid column access index");
+
+            return const_cast<MT const&>(matrix_)(i_ + i, j_ + j);
+        }
+
+
+        Pointer data() noexcept
+        {
+            return data_;
+        }
+
+
+        ConstPointer data() const noexcept
+        {
+            return data_;
+        }
+
+
+    private:
+        ViewedType matrix_;        //!< The matrix containing the submatrix.
+        size_t const i_;
+        size_t const j_;
+        size_t const m_;
+        size_t const n_;
+
+        // Pointer to the first element of the submatrix
+        Pointer const data_;
+    };
+
+
+    /**
+     * @brief Specialization for @a Submatrix class
+     */
+    template <typename MT, AlignmentFlag AF>
+    struct IsAligned<Submatrix<MT, AF>> : std::integral_constant<bool, AF> {};
+
+
+    /**
+     * @brief Submatrix of a matrix
+     *
+     * @tparam AF alignment flag of the resulting submatrix
+     * @tparam MT type of the matrix containing the submatrix
+     *
+     * @param matrix matrix containing the submatrix
+     * @param row top row index of the submatrix
+     * @param column left column index of the submatrix
+     * @param m number of rows in the resulting submatrix
+     * @param n number of columns in the resulting submatrix
+     *
+     * @return submatrix of @a matrix
+     */
+    template <AlignmentFlag AF, Matrix MT>
+    inline decltype(auto) submatrix(MT& matrix, size_t row, size_t column, size_t m, size_t n)
+    {
+        return Submatrix<MT, AF> {matrix, row, column, m, n};
+    }
+
+
+    /**
+     * @brief Submatrix of a const @a Submatrix
+     *
+     * @tparam AF alignment flag of the resulting submatrix
+     * @tparam MT type of the matrix containing the submatrix
+     * @tparam AF1 alignment flag of the matrix containing the submatrix
+     *
+     * @param matrix matrix containing the submatrix
+     * @param row top row index of the submatrix (relative to @a matrix)
+     * @param column left column index of the submatrix (relative to @a matrix)
+     * @param m number of rows in the resulting submatrix
+     * @param n number of columns in the resulting submatrix
+     *
+     * @return submatrix of @a matrix
+     */
+    template <AlignmentFlag AF, Matrix MT, AlignmentFlag AF1>
+    inline decltype(auto) submatrix(Submatrix<MT, AF1> const& matrix, size_t row, size_t column, size_t m, size_t n)
+    {
+        return Submatrix<MT const, AF> {matrix.operand(), matrix.row() + row, matrix.column() + column, m, n};
+    }
+
+
+    /**
+     * @brief Submatrix of a @a Submatrix
+     *
+     * @tparam AF alignment flag of the resulting submatrix
+     * @tparam MT type of the matrix containing the submatrix
+     * @tparam AF1 alignment flag of the matrix containing the submatrix
+     *
+     * @param matrix matrix containing the submatrix
+     * @param row top row index of the submatrix (relative to @a matrix)
+     * @param column left column index of the submatrix (relative to @a matrix)
+     * @param m number of rows in the resulting submatrix
+     * @param n number of columns in the resulting submatrix
+     *
+     * @return submatrix of @a matrix
+     */
+    template <AlignmentFlag AF, Matrix MT, AlignmentFlag AF1>
+    inline decltype(auto) submatrix(Submatrix<MT, AF1>& matrix, size_t row, size_t column, size_t m, size_t n)
+    {
+        return PanelSubmatrix<MT, AF> {matrix.operand(), matrix.row() + row, matrix.column() + column, m, n};
+    }
+}

--- a/include/blast/system/Restrict.hpp
+++ b/include/blast/system/Restrict.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+// Intel compiler
+#if defined(__INTEL_COMPILER) || defined(__ICL) || defined(__ICC) || defined(__ECC)
+#   define BLAST_RESTRICT __restrict
+
+// GNU compiler
+#elif defined(__GNUC__)
+#   define BLAST_RESTRICT __restrict
+
+// Microsoft visual studio
+#elif defined(_MSC_VER)
+#   define BLAST_RESTRICT __restrict
+
+// All other compilers
+#else
+#   define BLAST_RESTRICT
+#  endif

--- a/include/test/MakePositiveDefinite.hpp
+++ b/include/test/MakePositiveDefinite.hpp
@@ -1,0 +1,46 @@
+// Copyright 2024 Mikhail Katliar. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//*************************************************************************************************
+#pragma once
+
+#include <blast/math/TypeTraits.hpp>
+#include <blast/math/Matrix.hpp>
+#include <blast/math/dense/DynamicMatrix.hpp>
+
+#include <stdexcept>
+
+
+namespace blast :: testing
+{
+    /**
+     * @brief Setup of a random positive definite @a Matrix.
+     *
+     *
+     * @param matrix The matrix to be randomized.
+     *
+     * @throw @a std::invalid_argument if non-square matrix is provided
+     */
+    template <Matrix MT>
+    inline void makePositiveDefinite(MT& matrix)
+    {
+        using ET = ElementType_t<MT>;
+
+        size_t const N = columns(matrix);
+        if (rows(matrix) != N)
+            throw std::invalid_argument {"Non-square matrix provided"};
+
+        DynamicMatrix<ET> tmp(N, N);
+        randomize(tmp);
+
+        // TODO: this can be replaced by reference::gemm() when it is there.
+        reset(matrix);
+        for (size_t i = 0; i < N; ++i)
+            for (size_t j = 0; j < N; ++j)
+                for (size_t k = 0; k < N; ++k)
+                    matrix(i, j) += tmp(i, k) * tmp(k, j);
+
+        for (size_t i = 0; i < N; ++i)
+            matrix(i, i) += ET(N);
+    }
+}

--- a/include/test/Randomize.hpp
+++ b/include/test/Randomize.hpp
@@ -4,22 +4,39 @@
 
 #pragma once
 
-#include <blaze/util/Random.h>
+#include <blast/math/TypeTraits.hpp>
 
 #include <array>
 #include <vector>
+#include <random>
 
 
-namespace blast
+namespace blast :: testing
 {
-    using blaze::randomize;
+    namespace detail
+    {
+        inline auto& randomEngine()
+        {
+            static std::mt19937 engine;
+            return engine;
+        }
+    }
+
+
+    template <typename T>
+    requires std::is_floating_point_v<T>
+    inline void randomize(T& a)
+    {
+        std::uniform_real_distribution<T> dist;
+        a = dist(detail::randomEngine());
+    }
 
 
     template <typename T, std::size_t N>
     inline void randomize(std::array<T, N>& a)
     {
         for (T& v : a)
-            blaze::randomize(v);
+            randomize(v);
     }
 
 
@@ -27,6 +44,23 @@ namespace blast
     inline void randomize(std::vector<T>& a)
     {
         for (T& v : a)
-            blaze::randomize(v);
+            randomize(v);
+    }
+
+
+    template <Matrix M>
+    inline void randomize(M& m) noexcept
+    {
+        for (size_t i = 0; i < rows(m); ++i)
+            for (size_t j = 0; j < columns(m); ++j)
+                randomize(m(i, j));
+    }
+
+
+    template <Matrix M>
+    requires IsView_v<M>
+    inline void randomize(M&& m) noexcept
+    {
+        randomize(m);
     }
 }

--- a/include/test/Testing.hpp
+++ b/include/test/Testing.hpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
+#include <blast/math/TypeTraits.hpp>
 
 #include <blaze/util/typetraits/IsArithmetic.h>
 #include <blaze/math/Matrix.h>
@@ -18,191 +19,191 @@
 
 namespace blast :: testing
 {
-	using namespace ::testing;
+    using namespace ::testing;
 
 
-	namespace detail
-	{
-		template <typename T>
-		class ForcePrintImpl
-		: 	public T
-		{
-			friend void PrintTo(const ForcePrintImpl &m, ::std::ostream *o)
-			{
-				*o << "\n" << m;
-			}
-		};
-	}
+    namespace detail
+    {
+        template <typename T>
+        class ForcePrintImpl
+        : 	public T
+        {
+            friend void PrintTo(const ForcePrintImpl &m, ::std::ostream *o)
+            {
+                *o << "\n" << m;
+            }
+        };
+    }
 
 
-	/*
-	* Makes the Eigen3 matrix classes printable from GTest checking macros like EXPECT_EQ.
-	* Usage: EXPECT_EQ(forcePrint(a), forcePrint(b))
-	* Taken from this post: http://stackoverflow.com/questions/25146997/teach-google-test-how-to-print-eigen-matrix
-	*/
-	template <typename T>
-	decltype(auto) forcePrint(T const& val)
-	{
-		return static_cast<detail::ForcePrintImpl<T> const&>(val);
-	}
+    /*
+    * Makes the Eigen3 matrix classes printable from GTest checking macros like EXPECT_EQ.
+    * Usage: EXPECT_EQ(forcePrint(a), forcePrint(b))
+    * Taken from this post: http://stackoverflow.com/questions/25146997/teach-google-test-how-to-print-eigen-matrix
+    */
+    template <typename T>
+    decltype(auto) forcePrint(T const& val)
+    {
+        return static_cast<detail::ForcePrintImpl<T> const&>(val);
+    }
 
 
-	MATCHER_P(FloatNearPointwise, tol, "Out of range")
-	{
-		return (std::get<0>(arg) > std::get<1>(arg) - tol && std::get<0>(arg) < std::get<1>(arg) + tol) ;
-	}
+    MATCHER_P(FloatNearPointwise, tol, "Out of range")
+    {
+        return (std::get<0>(arg) > std::get<1>(arg) - tol && std::get<0>(arg) < std::get<1>(arg) + tol) ;
+    }
 
 
-	/// @brief Blaze matrix approx equality predicate
-	template <typename MT1, bool SO1, typename MT2, bool SO2, typename Real>
-	inline AssertionResult approxEqual(blaze::Matrix<MT1, SO1> const& lhs, blaze::Matrix<MT2, SO2> const& rhs, Real abs_tol, Real rel_tol = 0)
-	{
-		size_t const M = rows(lhs);
-		size_t const N = columns(lhs);
+    /// @brief Matrix approx equality predicate
+    template <Matrix MT1, Matrix MT2, typename Real>
+    inline AssertionResult approxEqual(MT1 const& lhs, MT2 const& rhs, Real abs_tol, Real rel_tol = 0)
+    {
+        size_t const M = rows(lhs);
+        size_t const N = columns(lhs);
 
-		if (rows(rhs) != M || columns(rhs) != N)
-			return AssertionFailure() << "Matrix size mismatch";
+        if (rows(rhs) != M || columns(rhs) != N)
+            return AssertionFailure() << "Matrix size mismatch";
 
-		for (size_t i = 0; i < M; ++i)
-			for (size_t j = 0; j < N; ++j)
-			{
-				auto const a = (*lhs)(i, j);
-				auto const b = (*rhs)(i, j);
-				auto delta = a - b;
+        for (size_t i = 0; i < M; ++i)
+            for (size_t j = 0; j < N; ++j)
+            {
+                auto const a = lhs(i, j);
+                auto const b = rhs(i, j);
+                auto delta = a - b;
 
-				if (std::isnan(a) != std::isnan(b)
-					|| std::abs(delta) > abs_tol + rel_tol * std::abs(b))
-					return AssertionFailure()
-						<< "Actual value:\n" << lhs
-						<< "Expected value:\n" << rhs
-						<< "First mismatch at index (" << i << ", " << j << ")";
-			}
+                if (std::isnan(a) != std::isnan(b)
+                    || std::abs(delta) > abs_tol + rel_tol * std::abs(b))
+                    return AssertionFailure()
+                        << "Actual value:\n" << lhs
+                        << "Expected value:\n" << rhs
+                        << "First mismatch at index (" << i << ", " << j << ")";
+            }
 
-		return AssertionSuccess();
-	}
-
-
-	/// @brief Blaze vector approx equality predicate
-	template <typename VT1, typename VT2, bool TF, typename Real>
-	inline std::enable_if_t<blaze::IsArithmetic_v<Real>, AssertionResult>
-		approxEqual(blaze::Vector<VT1, TF> const& lhs, blaze::Vector<VT2, TF> const& rhs, Real abs_tol, Real rel_tol = 0)
-	{
-		size_t const N = size(lhs);
-
-		if (size(rhs) != N)
-			return AssertionFailure() << "Vector size mismatch";
-
-		for (size_t j = 0; j < N; ++j)
-			if (abs((*lhs)[j] - (*rhs)[j]) > abs_tol + rel_tol * abs((*rhs)[j]))
-				return AssertionFailure()
-					<< "Actual value:\n" << lhs
-					<< "Expected value:\n" << rhs
-					<< "First mismatch at index (" << j << ")";
-
-		return AssertionSuccess();
-	}
+        return AssertionSuccess();
+    }
 
 
-	/// @brief Vector approx equality predicate with absolute tolerances specified for each element.
-	template <typename VT1, typename VT2, bool TF, typename Real>
-	inline AssertionResult approxEqual(blaze::Vector<VT1, TF> const& lhs, blaze::Vector<VT2, TF> const& rhs, std::initializer_list<Real> abs_tol)
-	{
-		size_t const N = size(abs_tol);
+    /// @brief Blaze vector approx equality predicate
+    template <typename VT1, typename VT2, bool TF, typename Real>
+    inline std::enable_if_t<blaze::IsArithmetic_v<Real>, AssertionResult>
+        approxEqual(blaze::Vector<VT1, TF> const& lhs, blaze::Vector<VT2, TF> const& rhs, Real abs_tol, Real rel_tol = 0)
+    {
+        size_t const N = size(lhs);
 
-		if (size(lhs) != N || size(rhs) != N)
-			return AssertionFailure() << "Vector size mismatch";
+        if (size(rhs) != N)
+            return AssertionFailure() << "Vector size mismatch";
 
-		auto atol = begin(abs_tol);
+        for (size_t j = 0; j < N; ++j)
+            if (abs((*lhs)[j] - (*rhs)[j]) > abs_tol + rel_tol * abs((*rhs)[j]))
+                return AssertionFailure()
+                    << "Actual value:\n" << lhs
+                    << "Expected value:\n" << rhs
+                    << "First mismatch at index (" << j << ")";
 
-		for (size_t j = 0; j < N; ++j, ++atol)
-			if (abs((*lhs)[j] - (*rhs)[j]) > *atol)
-				return AssertionFailure() << "First element mismatch at index "
-					<< j << ", lhs=" << (*lhs)[j] << ", rhs=" << (*rhs)[j] << ", abs_tol=" << *atol;
-
-		return AssertionSuccess();
-	}
-
-
-	/// @brief Vector approx equality predicate with absolute tolerances specified for each element.
-	template <typename VT1, typename VT2, typename VT3, bool TF>
-	inline AssertionResult approxEqual(blaze::Vector<VT1, TF> const& lhs, blaze::Vector<VT2, TF> const& rhs, blaze::Vector<VT3, TF> const& abs_tol)
-	{
-		size_t const N = size(abs_tol);
-
-		if (size(lhs) != N || size(rhs) != N)
-			return AssertionFailure() << "Vector size mismatch";
-
-		for (size_t j = 0; j < N; ++j)
-			if (abs((*lhs)[j] - (*rhs)[j]) > (*abs_tol)[j])
-				return AssertionFailure() << "First element mismatch at index "
-					<< j << ", lhs=" << (*lhs)[j] << ", rhs=" << (*rhs)[j] << ", abs_tol=" << (*abs_tol)[j];
-
-		return AssertionSuccess();
-	}
+        return AssertionSuccess();
+    }
 
 
-	/// @brief Scalar type approx equality predicate with specified tolerances.
-	///
-	template <typename Scalar>
-	requires std::is_floating_point_v<Scalar>
-	inline AssertionResult approxEqual(Scalar actual, Scalar expected, Scalar abs_tol, Scalar rel_tol)
-	{
-		if (std::abs(actual - expected) > abs_tol + rel_tol * std::abs(expected))
-			return AssertionFailure()
-				<< "Floating point values differ more than by the specified tolerance." << std::endl
-				<< "Actual: " << actual << ", expected: " << expected;
+    /// @brief Vector approx equality predicate with absolute tolerances specified for each element.
+    template <typename VT1, typename VT2, bool TF, typename Real>
+    inline AssertionResult approxEqual(blaze::Vector<VT1, TF> const& lhs, blaze::Vector<VT2, TF> const& rhs, std::initializer_list<Real> abs_tol)
+    {
+        size_t const N = size(abs_tol);
 
-		return AssertionSuccess();
-	}
+        if (size(lhs) != N || size(rhs) != N)
+            return AssertionFailure() << "Vector size mismatch";
 
+        auto atol = begin(abs_tol);
 
-	/// @brief Exact equality comparison for matrices
-	template <typename MT1, bool SO1, typename MT2, bool SO2>
-	inline AssertionResult exactEqual(blaze::Matrix<MT1, SO1> const& lhs, blaze::Matrix<MT2, SO2> const& rhs)
-	{
-		size_t const M = rows(lhs);
-		size_t const N = columns(lhs);
+        for (size_t j = 0; j < N; ++j, ++atol)
+            if (abs((*lhs)[j] - (*rhs)[j]) > *atol)
+                return AssertionFailure() << "First element mismatch at index "
+                    << j << ", lhs=" << (*lhs)[j] << ", rhs=" << (*rhs)[j] << ", abs_tol=" << *atol;
 
-		if (rows(rhs) != M || columns(rhs) != N)
-			return AssertionFailure() << "Matrix size mismatch";
-
-		for (size_t i = 0; i < M; ++i)
-			for (size_t j = 0; j < N; ++j)
-				if (!((*lhs)(i, j) == (*rhs)(i, j)))
-					return AssertionFailure() << "First element mismatch at index ("
-						<< i << "," << j << "), lhs=" << (*lhs)(i, j) << ", rhs=" << (*rhs)(i, j);
-
-		return AssertionSuccess();
-	}
+        return AssertionSuccess();
+    }
 
 
-	/// @brief Exact equality comparison for vectors
-	template <typename VT1, typename VT2, bool TF>
-	inline AssertionResult exactEqual(blaze::Vector<VT1, TF> const& lhs, blaze::Vector<VT2, TF> const& rhs)
-	{
-		size_t const N = size(lhs);
+    /// @brief Vector approx equality predicate with absolute tolerances specified for each element.
+    template <typename VT1, typename VT2, typename VT3, bool TF>
+    inline AssertionResult approxEqual(blaze::Vector<VT1, TF> const& lhs, blaze::Vector<VT2, TF> const& rhs, blaze::Vector<VT3, TF> const& abs_tol)
+    {
+        size_t const N = size(abs_tol);
 
-		if (size(rhs) != N)
-			return AssertionFailure() << "Vector size mismatch";
+        if (size(lhs) != N || size(rhs) != N)
+            return AssertionFailure() << "Vector size mismatch";
 
-		for (size_t j = 0; j < N; ++j)
-			if (!((*lhs)[j] == (*rhs)[j]))
-				return AssertionFailure() << "First element mismatch at index "
-					<< j << ", lhs=" << (*lhs)[j] << ", rhs=" << (*rhs)[j];
+        for (size_t j = 0; j < N; ++j)
+            if (abs((*lhs)[j] - (*rhs)[j]) > (*abs_tol)[j])
+                return AssertionFailure() << "First element mismatch at index "
+                    << j << ", lhs=" << (*lhs)[j] << ", rhs=" << (*rhs)[j] << ", abs_tol=" << (*abs_tol)[j];
 
-		return AssertionSuccess();
-	}
+        return AssertionSuccess();
+    }
+
+
+    /// @brief Scalar type approx equality predicate with specified tolerances.
+    ///
+    template <typename Scalar>
+    requires std::is_floating_point_v<Scalar>
+    inline AssertionResult approxEqual(Scalar actual, Scalar expected, Scalar abs_tol, Scalar rel_tol)
+    {
+        if (std::abs(actual - expected) > abs_tol + rel_tol * std::abs(expected))
+            return AssertionFailure()
+                << "Floating point values differ more than by the specified tolerance." << std::endl
+                << "Actual: " << actual << ", expected: " << expected;
+
+        return AssertionSuccess();
+    }
+
+
+    /// @brief Exact equality comparison for matrices
+    template <typename MT1, bool SO1, typename MT2, bool SO2>
+    inline AssertionResult exactEqual(blaze::Matrix<MT1, SO1> const& lhs, blaze::Matrix<MT2, SO2> const& rhs)
+    {
+        size_t const M = rows(lhs);
+        size_t const N = columns(lhs);
+
+        if (rows(rhs) != M || columns(rhs) != N)
+            return AssertionFailure() << "Matrix size mismatch";
+
+        for (size_t i = 0; i < M; ++i)
+            for (size_t j = 0; j < N; ++j)
+                if (!((*lhs)(i, j) == (*rhs)(i, j)))
+                    return AssertionFailure() << "First element mismatch at index ("
+                        << i << "," << j << "), lhs=" << (*lhs)(i, j) << ", rhs=" << (*rhs)(i, j);
+
+        return AssertionSuccess();
+    }
+
+
+    /// @brief Exact equality comparison for vectors
+    template <typename VT1, typename VT2, bool TF>
+    inline AssertionResult exactEqual(blaze::Vector<VT1, TF> const& lhs, blaze::Vector<VT2, TF> const& rhs)
+    {
+        size_t const N = size(lhs);
+
+        if (size(rhs) != N)
+            return AssertionFailure() << "Vector size mismatch";
+
+        for (size_t j = 0; j < N; ++j)
+            if (!((*lhs)[j] == (*rhs)[j]))
+                return AssertionFailure() << "First element mismatch at index "
+                    << j << ", lhs=" << (*lhs)[j] << ", rhs=" << (*rhs)[j];
+
+        return AssertionSuccess();
+    }
 }
 
 
 #define BLAST_EXPECT_APPROX_EQ(val, expected, abs_tol, rel_tol) \
-	EXPECT_TRUE(::blast::testing::approxEqual(val, expected, abs_tol, rel_tol))
+    EXPECT_TRUE(::blast::testing::approxEqual(val, expected, abs_tol, rel_tol))
 
 #define BLAST_ASSERT_APPROX_EQ(val, expected, abs_tol, rel_tol) \
-	ASSERT_TRUE(::blast::testing::approxEqual(val, expected, abs_tol, rel_tol))
+    ASSERT_TRUE(::blast::testing::approxEqual(val, expected, abs_tol, rel_tol))
 
 #define BLAST_EXPECT_EQ(val, expected) \
-	EXPECT_EQ(::blast::testing::forcePrint(val), ::blast::testing::forcePrint(expected))
+    EXPECT_EQ(::blast::testing::forcePrint(val), ::blast::testing::forcePrint(expected))
 
 #define BLAST_ASSERT_EQ(val, expected) \
-	ASSERT_EQ(::blast::testing::forcePrint(val), ::blast::testing::forcePrint(expected))
+    ASSERT_EQ(::blast::testing::forcePrint(val), ::blast::testing::forcePrint(expected))

--- a/test/blast/math/dense/GemmTest.cpp
+++ b/test/blast/math/dense/GemmTest.cpp
@@ -7,7 +7,7 @@
 #include <blast/math/algorithm/Gemm.hpp>
 
 #include <test/Testing.hpp>
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 #include <blast/blaze/Math.hpp>
 

--- a/test/blast/math/dense/GerTest.cpp
+++ b/test/blast/math/dense/GerTest.cpp
@@ -10,7 +10,7 @@
 #include <blast/math/Vector.hpp>
 
 #include <test/Testing.hpp>
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 namespace blast :: testing
 {

--- a/test/blast/math/dense/Getf2Test.cpp
+++ b/test/blast/math/dense/Getf2Test.cpp
@@ -7,7 +7,7 @@
 #include <blast/blaze/Math.hpp>
 
 #include <test/Testing.hpp>
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 #include <test/Tolerance.hpp>
 
 #include <vector>

--- a/test/blast/math/dense/GetrfTest.cpp
+++ b/test/blast/math/dense/GetrfTest.cpp
@@ -9,7 +9,7 @@
 #include <blast/blaze/Math.hpp>
 
 #include <test/Testing.hpp>
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 #include <test/Tolerance.hpp>
 
 #include <vector>

--- a/test/blast/math/dense/Iamax.cpp
+++ b/test/blast/math/dense/Iamax.cpp
@@ -6,7 +6,7 @@
 #include <blast/blaze/Math.hpp>
 
 #include <test/Testing.hpp>
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 
 namespace blast :: testing

--- a/test/blast/math/dense/PotrfTest.cpp
+++ b/test/blast/math/dense/PotrfTest.cpp
@@ -5,7 +5,7 @@
 #include <blast/math/dense/Potrf.hpp>
 
 #include <test/Testing.hpp>
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 #include <test/Tolerance.hpp>
 
 #include <blast/blaze/Math.hpp>

--- a/test/blast/math/dense/SyrkTest.cpp
+++ b/test/blast/math/dense/SyrkTest.cpp
@@ -7,7 +7,7 @@
 #include <blast/math/dense/Syrk.hpp>
 
 #include <test/Testing.hpp>
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 #include <blast/blaze/Math.hpp>
 

--- a/test/blast/math/dense/TrmmTest.cpp
+++ b/test/blast/math/dense/TrmmTest.cpp
@@ -7,7 +7,7 @@
 #include <blast/blaze/Math.hpp>
 
 #include <test/Testing.hpp>
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 namespace blast :: testing
 {

--- a/test/blast/math/expressions/AssignDensePanelTest.cpp
+++ b/test/blast/math/expressions/AssignDensePanelTest.cpp
@@ -7,7 +7,7 @@
 #include <blaze/Math.h>
 
 #include <test/Testing.hpp>
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 
 namespace blast :: testing

--- a/test/blast/math/expressions/AssignPanelDenseTest.cpp
+++ b/test/blast/math/expressions/AssignPanelDenseTest.cpp
@@ -7,7 +7,7 @@
 #include <blaze/Math.h>
 
 #include <test/Testing.hpp>
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 
 namespace blast :: testing

--- a/test/blast/math/expressions/PMatTransExprTest.cpp
+++ b/test/blast/math/expressions/PMatTransExprTest.cpp
@@ -6,7 +6,7 @@
 #include <blast/math/DynamicPanelMatrix.hpp>
 
 #include <test/Testing.hpp>
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 
 namespace blast :: testing

--- a/test/blast/math/panel/DynamicPanelMatrixTest.cpp
+++ b/test/blast/math/panel/DynamicPanelMatrixTest.cpp
@@ -7,7 +7,7 @@
 #include <blaze/Math.h>
 
 #include <test/Testing.hpp>
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 
 namespace blast :: testing

--- a/test/blast/math/panel/GemmTest.cpp
+++ b/test/blast/math/panel/GemmTest.cpp
@@ -12,7 +12,7 @@
 #include <blaze/Math.h>
 
 #include <test/Testing.hpp>
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 #include <test/Tolerance.hpp>
 
 

--- a/test/blast/math/panel/PotrfTest.cpp
+++ b/test/blast/math/panel/PotrfTest.cpp
@@ -8,7 +8,7 @@
 #include <blast/blaze/Math.hpp>
 
 #include <test/Testing.hpp>
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 #include <test/Tolerance.hpp>
 
 namespace blast :: testing

--- a/test/blast/math/panel/StaticPanelMatrixTest.cpp
+++ b/test/blast/math/panel/StaticPanelMatrixTest.cpp
@@ -10,7 +10,7 @@
 
 #include <blaze/math/AlignmentFlag.h>
 #include <test/Testing.hpp>
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 
 namespace blast :: testing

--- a/test/blast/math/simd/DynamicRegisterMatrixTest.cpp
+++ b/test/blast/math/simd/DynamicRegisterMatrixTest.cpp
@@ -9,7 +9,7 @@
 #include <blast/blaze/Math.hpp>
 
 #include <test/Testing.hpp>
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 #include <test/Tolerance.hpp>
 
 

--- a/test/blast/math/simd/RegisterMatrixTest.cpp
+++ b/test/blast/math/simd/RegisterMatrixTest.cpp
@@ -9,10 +9,12 @@
 #include <blast/math/reference/Ger.hpp>
 #include <blast/math/panel/StaticPanelMatrix.hpp>
 #include <blast/math/dense/StaticMatrix.hpp>
+// #include <blast/math/expressions/TransExpr.hpp>
 
 #include <test/Testing.hpp>
 #include <test/Randomize.hpp>
 #include <test/Tolerance.hpp>
+// #include <test/MakePositiveDefinite.hpp>
 
 
 namespace blast :: testing

--- a/test/blast/math/simd/RegisterMatrixTest.cpp
+++ b/test/blast/math/simd/RegisterMatrixTest.cpp
@@ -8,7 +8,7 @@
 #include <blast/math/views/Submatrix.hpp>
 #include <blast/math/reference/Ger.hpp>
 #include <blast/math/reference/Gemm.hpp>
-#include <blast/math/panel/StaticPanelMatrix.hpp>
+#include <blast/math/StaticPanelMatrix.hpp>
 #include <blast/math/dense/StaticMatrix.hpp>
 #include <blast/math/expressions/MatTransExpr.hpp>
 
@@ -502,133 +502,131 @@ namespace blast :: testing
     }
 
 
-    // TYPED_TEST(RegisterMatrixTest, testTrsmRltPanel)
-    // {
-    //     using RM = TypeParam;
-    //     using Traits = RegisterMatrixTraits<RM>;
-    //     using ET = ElementType_t<RM>;
+    TYPED_TEST(RegisterMatrixTest, testTrsmRltPanel)
+    {
+        using RM = TypeParam;
+        using Traits = RegisterMatrixTraits<RM>;
+        using ET = ElementType_t<RM>;
 
-    //     RM ker;
+        RM ker;
 
-    //     using blaze::randomize;
-    //     StaticPanelMatrix<ET, Traits::columns, Traits::columns, columnMajor> L;
-    //     StaticPanelMatrix<ET, Traits::rows, Traits::columns, columnMajor> B, X, B1;
+        using blaze::randomize;
+        StaticPanelMatrix<ET, Traits::columns, Traits::columns, columnMajor> L;
+        StaticPanelMatrix<ET, Traits::rows, Traits::columns, columnMajor> B, X, B1;
 
-    //     for (size_t i = 0; i < Traits::columns; ++i)
-    //         for (size_t j = 0; j < Traits::columns; ++j)
-    //             if (j <= i)
-    //             {
-    //                 randomize(L(i, j));
-    //                 if (i == j)
-    //                     L(i, j) += ET(1.);  // Improve conditioning
-    //             }
-    //             else
-    //                 reset(L(i, j));
+        for (size_t i = 0; i < Traits::columns; ++i)
+            for (size_t j = 0; j < Traits::columns; ++j)
+                if (j <= i)
+                {
+                    randomize(L(i, j));
+                    if (i == j)
+                        L(i, j) += ET(1.);  // Improve conditioning
+                }
+                else
+                    L(i, j) = ET(0.);
 
-    //     randomize(B);
+        randomize(B);
 
-    //     StaticMatrix<ET, Traits::columns, Traits::columns, columnMajor> LL;
-    //     StaticMatrix<ET, Traits::rows, Traits::columns, columnMajor> BB, XX;
+        blaze::StaticMatrix<ET, Traits::columns, Traits::columns, columnMajor> LL;
+        blaze::StaticMatrix<ET, Traits::rows, Traits::columns, columnMajor> BB, XX;
 
-    //     LL = L;
-    //     BB = B;
+        LL = L;
+        BB = B;
 
-    //     // True value
-    //     XX = evaluate(BB * inv(trans(LL)));
+        // True value
+        XX = evaluate(BB * inv(blaze::trans(LL)));
 
-    //     ker.load(ptr(B));
-    //     ker.trsm(Side::Right, UpLo::Upper, ptr(L).trans());
-    //     ker.store(ptr(X));
+        ker.load(ptr(B));
+        ker.trsm(Side::Right, UpLo::Upper, ptr(L).trans());
+        ker.store(ptr(X));
 
-    //     // TODO: should be strictly equal?
-    //     BLAST_ASSERT_APPROX_EQ(X, XX, absTol<ET>(), relTol<ET>());
-    // }
-
-
-    // TYPED_TEST(RegisterMatrixTest, testTrsmRltDense)
-    // {
-    //     using RM = TypeParam;
-    //     using ET = ElementType_t<RM>;
-
-    //     RM ker;
-
-    //     using blaze::randomize;
-    //     StaticMatrix<ET, RM::columns(), RM::columns(), columnMajor> L;
-    //     StaticMatrix<ET, RM::rows(), RM::columns(), columnMajor> B, B1;
-
-    //     for (size_t i = 0; i < RM::columns(); ++i)
-    //         for (size_t j = 0; j < RM::columns(); ++j)
-    //             if (j <= i)
-    //             {
-    //                 randomize(L(i, j));
-    //                 if (i == j)
-    //                     L(i, j) += ET(1.);  // Improve conditioning
-    //             }
-    //             else
-    //                 reset(L(i, j));
-
-    //     randomize(B);
-
-    //     ker.load(ptr(B));
-    //     ker.trsm(Side::Right, UpLo::Upper, trans(ptr(L)));
-
-    //     // TODO: should be strictly equal?
-    //     BLAST_ASSERT_APPROX_EQ(ker, evaluate(B * inv(trans(L))), absTol<ET>(), relTol<ET>());
-    // }
+        // TODO: should be strictly equal?
+        BLAST_ASSERT_APPROX_EQ(X, XX, absTol<ET>(), relTol<ET>());
+    }
 
 
-    // TYPED_TEST(RegisterMatrixTest, testTrmmLeftUpper)
-    // {
-    //     using RM = TypeParam;
-    //     using ET = ElementType_t<RM>;
+    TYPED_TEST(RegisterMatrixTest, testTrsmRltDense)
+    {
+        using RM = TypeParam;
+        using ET = ElementType_t<RM>;
+
+        RM ker;
+
+        using blaze::randomize;
+        blaze::StaticMatrix<ET, RM::columns(), RM::columns(), columnMajor> L;
+        blaze::StaticMatrix<ET, RM::rows(), RM::columns(), columnMajor> B, B1;
+
+        for (size_t i = 0; i < RM::columns(); ++i)
+            for (size_t j = 0; j < RM::columns(); ++j)
+                if (j <= i)
+                {
+                    randomize(L(i, j));
+                    if (i == j)
+                        L(i, j) += ET(1.);  // Improve conditioning
+                }
+                else
+                    blaze::reset(L(i, j));
+
+        randomize(B);
+
+        ker.load(ptr(B));
+        ker.trsm(Side::Right, UpLo::Upper, trans(ptr(L)));
+
+        // TODO: should be strictly equal?
+        BLAST_ASSERT_APPROX_EQ(ker, evaluate(B * inv(blaze::trans(L))), absTol<ET>(), relTol<ET>());
+    }
 
 
-    //     DynamicMatrix<ET, columnMajor> A(RM::rows(), RM::rows());
-    //     DynamicMatrix<ET, columnMajor> B(RM::rows(), RM::columns());
+    TYPED_TEST(RegisterMatrixTest, testTrmmLeftUpper)
+    {
+        using RM = TypeParam;
+        using ET = ElementType_t<RM>;
 
-    //     randomize(A);
-    //     randomize(B);
+        blaze::DynamicMatrix<ET, columnMajor> A(RM::rows(), RM::rows());
+        blaze::DynamicMatrix<ET, columnMajor> B(RM::rows(), RM::columns());
 
-    //     ET alpha {};
-    //     blaze::randomize(alpha);
+        blaze::randomize(A);
+        blaze::randomize(B);
 
-    //     RM ker;
-    //     ker.trmmLeftUpper(alpha, ptr(A), ptr(B));
+        ET alpha {};
+        blaze::randomize(alpha);
 
-    //     // Reset lower-triangular part
-    //     for (size_t i = 0; i < A.rows(); ++i)
-    //         for (size_t j = 0; j < i && j < A.columns(); ++j)
-    //             reset(A(i, j));
+        RM ker;
+        ker.trmmLeftUpper(alpha, ptr(A), ptr(B));
 
-    //     // TODO: should be strictly equal?
-    //     BLAST_ASSERT_APPROX_EQ(ker, alpha * A * B, absTol<ET>(), relTol<ET>());
-    // }
+        // Reset lower-triangular part
+        for (size_t i = 0; i < A.rows(); ++i)
+            for (size_t j = 0; j < i && j < A.columns(); ++j)
+                blaze::reset(A(i, j));
 
-
-    // TYPED_TEST(RegisterMatrixTest, testTrmmRightLower)
-    // {
-    //     using RM = TypeParam;
-    //     using ET = ElementType_t<RM>;
+        // TODO: should be strictly equal?
+        BLAST_ASSERT_APPROX_EQ(ker, alpha * A * B, absTol<ET>(), relTol<ET>());
+    }
 
 
-    //     DynamicMatrix<ET, columnMajor> A(RM::columns(), RM::columns());
-    //     DynamicMatrix<ET, columnMajor> B(RM::rows(), RM::columns());
+    TYPED_TEST(RegisterMatrixTest, testTrmmRightLower)
+    {
+        using RM = TypeParam;
+        using ET = ElementType_t<RM>;
 
-    //     randomize(A);
-    //     randomize(B);
+        blaze::DynamicMatrix<ET, columnMajor> A(RM::columns(), RM::columns());
+        blaze::DynamicMatrix<ET, columnMajor> B(RM::rows(), RM::columns());
 
-    //     ET alpha {};
-    //     blaze::randomize(alpha);
+        blaze::randomize(A);
+        blaze::randomize(B);
 
-    //     RM ker;
-    //     ker.trmmRightLower(alpha, ptr(B), ptr(A));
+        ET alpha {};
+        blaze::randomize(alpha);
 
-    //     // Reset upper-triangular part
-    //     for (size_t i = 0; i < A.rows(); ++i)
-    //         for (size_t j = i + 1; j < A.columns(); ++j)
-    //             reset(A(i, j));
+        RM ker;
+        ker.trmmRightLower(alpha, ptr(B), ptr(A));
 
-    //     // TODO: should be strictly equal?
-    //     BLAST_ASSERT_APPROX_EQ(ker, alpha * B * A, absTol<ET>(), relTol<ET>());
-    // }
+        // Reset upper-triangular part
+        for (size_t i = 0; i < A.rows(); ++i)
+            for (size_t j = i + 1; j < A.columns(); ++j)
+                blaze::reset(A(i, j));
+
+        // TODO: should be strictly equal?
+        BLAST_ASSERT_APPROX_EQ(ker, alpha * B * A, absTol<ET>(), relTol<ET>());
+    }
 }

--- a/test/blast/math/simd/RegisterMatrixTest.cpp
+++ b/test/blast/math/simd/RegisterMatrixTest.cpp
@@ -11,11 +11,11 @@
 #include <blast/math/StaticPanelMatrix.hpp>
 #include <blast/math/dense/StaticMatrix.hpp>
 #include <blast/math/expressions/MatTransExpr.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
+#include <blast/math/algorithm/MakePositiveDefinite.hpp>
 
 #include <test/Testing.hpp>
-#include <test/Randomize.hpp>
 #include <test/Tolerance.hpp>
-#include <test/MakePositiveDefinite.hpp>
 
 
 namespace blast :: testing

--- a/test/blast/math/simd/SimdVecTest.cpp
+++ b/test/blast/math/simd/SimdVecTest.cpp
@@ -7,7 +7,7 @@
 #include <blaze/Math.h>
 
 #include <test/Testing.hpp>
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 #include <array>
 #include <algorithm>

--- a/test/blast/math/views/RowTest.cpp
+++ b/test/blast/math/views/RowTest.cpp
@@ -6,7 +6,7 @@
 #include <blast/math/DynamicPanelMatrix.hpp>
 
 #include <test/Testing.hpp>
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 
 namespace blast :: testing

--- a/test/blast/math/views/SubmatrixTest.cpp
+++ b/test/blast/math/views/SubmatrixTest.cpp
@@ -7,7 +7,7 @@
 #include <blast/math/views/submatrix/Panel.hpp>
 
 #include <test/Testing.hpp>
-#include <test/Randomize.hpp>
+#include <blast/math/algorithm/Randomize.hpp>
 
 
 namespace blast :: testing


### PR DESCRIPTION
The primary goal was to make the `RegisterMatrixTest.testPotrf` work on ARM. The Blaze matrices had to be replaced by BLAST matrices, and multiple other changes were required to achieve this.

This PR is big, but it is difficult to split it into smaller ones, because the changes are not independent. Summary of the changes:
- `RegisterMatrixTest.testPotrf` works
- Added reference `gemm()` implementation
- Cleaned-up few other tests in `RegisterMatrixTest`
- Added `DynamicMatrix` class
- Functions `trans()`, `submatrix()`, `randomize()`, `makePositiveDefinite()` implemented for BLAST matrices
- `Randomize.hpp` moved to `blast/math/algorithm`.
- The [Testing.hpp](https://github.com/mkatliar/blast/pull/38/files#diff-d04fdb983604078d3e282357bebf2dd844bdf98489f67486073b1be846b80275) file ~300 lines of formatting changes