### PR TITLE
trmm() refactoring

### DIFF
--- a/bench/blast/math/dense/StaticTrmm.cpp
+++ b/bench/blast/math/dense/StaticTrmm.cpp
@@ -24,7 +24,7 @@ namespace blast :: benchmark
 
         for (auto _ : state)
         {
-            trmmLeftUpper(1., A, B, C);
+            trmm(1., A, UpLo::Upper, false, B, C);
             DoNotOptimize(A);
             DoNotOptimize(B);
             DoNotOptimize(C);
@@ -48,7 +48,7 @@ namespace blast :: benchmark
 
         for (auto _ : state)
         {
-            trmmRightLower(1., B, A, C);
+            trmm(1., B, A, UpLo::Lower, false, C);
             DoNotOptimize(A);
             DoNotOptimize(B);
             DoNotOptimize(C);

--- a/bench/blast/math/simd/Trmm.cpp
+++ b/bench/blast/math/simd/Trmm.cpp
@@ -14,8 +14,8 @@
 
 namespace blast :: benchmark
 {
-    template <typename T, size_t M, size_t N, bool SO>
-    static void BM_RegisterMatrix_trmmLeftUpper(State& state)
+    template <typename T, size_t M, size_t N, bool SO, UpLo UPLO>
+    static void BM_RegisterMatrix_trmmLeft(State& state)
     {
         using Kernel = RegisterMatrix<T, M, N, SO>;
         size_t constexpr K = 100;
@@ -30,7 +30,7 @@ namespace blast :: benchmark
 
         for (auto _ : state)
         {
-            ker.trmmLeftUpper(T(1.), ptr<aligned>(A, 0, 0), ptr<aligned>(B, 0, 0));
+            ker.trmm(T(1.), ptr(A), UPLO, false, ptr(B));
             DoNotOptimize(ker);
         }
 
@@ -38,8 +38,8 @@ namespace blast :: benchmark
     }
 
 
-    template <typename T, size_t M, size_t N, bool SO>
-    static void BM_RegisterMatrix_trmmRightLower(State& state)
+    template <typename T, size_t M, size_t N, bool SO, UpLo UPLO>
+    static void BM_RegisterMatrix_trmmRight(State& state)
     {
         using Kernel = RegisterMatrix<T, M, N, SO>;
         size_t constexpr K = 100;
@@ -54,7 +54,7 @@ namespace blast :: benchmark
 
         for (auto _ : state)
         {
-            ker.trmmRightLower(T(1.), ptr<aligned>(A, 0, 0), ptr<aligned>(B, 0, 0));
+            ker.trmm(T(1.), ptr(A), ptr(B), UPLO, false);
             DoNotOptimize(ker);
         }
 
@@ -62,23 +62,23 @@ namespace blast :: benchmark
     }
 
 
-    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmLeftUpper, double, 4, 4, columnMajor);
-    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmLeftUpper, double, 4, 8, columnMajor);
-    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmLeftUpper, double, 8, 4, columnMajor);
-    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmLeftUpper, double, 12, 4, columnMajor);
-    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmLeftUpper, float, 8, 4, columnMajor);
-    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmLeftUpper, float, 16, 4, columnMajor);
-    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmLeftUpper, float, 24, 4, columnMajor);
-    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmLeftUpper, float, 16, 5, columnMajor);
-    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmLeftUpper, float, 16, 6, columnMajor);
+    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmLeft, double, 4, 4, columnMajor, UpLo::Upper);
+    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmLeft, double, 4, 8, columnMajor, UpLo::Upper);
+    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmLeft, double, 8, 4, columnMajor, UpLo::Upper);
+    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmLeft, double, 12, 4, columnMajor, UpLo::Upper);
+    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmLeft, float, 8, 4, columnMajor, UpLo::Upper);
+    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmLeft, float, 16, 4, columnMajor, UpLo::Upper);
+    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmLeft, float, 24, 4, columnMajor, UpLo::Upper);
+    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmLeft, float, 16, 5, columnMajor, UpLo::Upper);
+    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmLeft, float, 16, 6, columnMajor, UpLo::Upper);
 
-    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmRightLower, double, 4, 4, columnMajor);
-    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmRightLower, double, 4, 8, columnMajor);
-    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmRightLower, double, 8, 4, columnMajor);
-    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmRightLower, double, 12, 4, columnMajor);
-    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmRightLower, float, 8, 4, columnMajor);
-    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmRightLower, float, 16, 4, columnMajor);
-    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmRightLower, float, 24, 4, columnMajor);
-    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmRightLower, float, 16, 5, columnMajor);
-    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmRightLower, float, 16, 6, columnMajor);
+    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmRight, double, 4, 4, columnMajor, UpLo::Lower);
+    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmRight, double, 4, 8, columnMajor, UpLo::Lower);
+    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmRight, double, 8, 4, columnMajor, UpLo::Lower);
+    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmRight, double, 12, 4, columnMajor, UpLo::Lower);
+    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmRight, float, 8, 4, columnMajor, UpLo::Lower);
+    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmRight, float, 16, 4, columnMajor, UpLo::Lower);
+    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmRight, float, 24, 4, columnMajor, UpLo::Lower);
+    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmRight, float, 16, 5, columnMajor, UpLo::Lower);
+    BENCHMARK_TEMPLATE(BM_RegisterMatrix_trmmRight, float, 16, 6, columnMajor, UpLo::Lower);
 }

--- a/include/blast/math/algorithm/Trmm.hpp
+++ b/include/blast/math/algorithm/Trmm.hpp
@@ -35,7 +35,7 @@ namespace blast
                 for (; j + KN <= N; j += KN)
                 {
                     ker.reset();
-                    ker.trmmLeftUpper(alpha, a, b(0, j));
+                    ker.trmm(alpha, a, UpLo::Upper, false, b(0, j));
                     gemm(ker, M - KM, alpha, a(0, KM), b(KM, j));
                     ker.store(c(0, j));
                 }
@@ -151,9 +151,6 @@ namespace blast
         using ET = ST;
         size_t constexpr TILE_SIZE = TileSize_v<ET>;
 
-        if (diagonal_unit)
-            BLAST_THROW_EXCEPTION(std::logic_error {"Unit-triangular matrices support not implemented in trmm()"});
-
         if (uplo == UpLo::Lower)
         {
             size_t j = 0;
@@ -169,7 +166,7 @@ namespace blast
                 for (; i + 3 * TILE_SIZE <= M && i + 4 * TILE_SIZE != M; i += 3 * TILE_SIZE)
                 {
                     RegisterMatrix<ET, 3 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                    ker.trmmRightLower(alpha, B(i, j), A(j, j));
+                    ker.trmm(alpha, B(i, j), A(j, j), UpLo::Lower, diagonal_unit);
                     gemm(ker, N - j - TILE_SIZE, alpha, B(i, j + TILE_SIZE), A(j + TILE_SIZE, j));
                     ker.store(C(i, j));
                 }
@@ -177,7 +174,7 @@ namespace blast
                 for (; i + 2 * TILE_SIZE <= M; i += 2 * TILE_SIZE)
                 {
                     RegisterMatrix<ET, 2 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                    ker.trmmRightLower(alpha, B(i, j), A(j, j));
+                    ker.trmm(alpha, B(i, j), A(j, j), UpLo::Lower, diagonal_unit);
                     gemm(ker, N - j - TILE_SIZE, alpha, B(i, j + TILE_SIZE), A(j + TILE_SIZE, j));
                     ker.store(C(i, j));
                 }
@@ -185,7 +182,7 @@ namespace blast
                 for (; i + 1 * TILE_SIZE <= M; i += 1 * TILE_SIZE)
                 {
                     RegisterMatrix<ET, 1 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                    ker.trmmRightLower(alpha, B(i, j), A(j, j));
+                    ker.trmm(alpha, B(i, j), A(j, j), UpLo::Lower, diagonal_unit);
                     gemm(ker, N - j - TILE_SIZE, alpha, B(i, j + TILE_SIZE), A(j + TILE_SIZE, j));
                     ker.store(C(i, j));
                 }
@@ -194,7 +191,7 @@ namespace blast
                 if (i < M)
                 {
                     RegisterMatrix<ET, TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                    ker.trmmRightLower(alpha, B(i, j), A(j, j), M - i, ker.columns());
+                    ker.trmm(alpha, B(i, j), A(j, j), UpLo::Lower, diagonal_unit, M - i, ker.columns());
                     gemm(ker, N - j - TILE_SIZE, alpha, B(i, j + TILE_SIZE), A(j + TILE_SIZE, j), M - i, ker.columns());
                     ker.store(C(i, j), M - i, ker.columns());
                 }
@@ -211,21 +208,21 @@ namespace blast
                 for (; i + 3 * TILE_SIZE <= M && i + 4 * TILE_SIZE != M; i += 3 * TILE_SIZE)
                 {
                     RegisterMatrix<ET, 3 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                    ker.trmmRightLower(alpha, B(i, j), A(j, j), ker.rows(), N - j);
+                    ker.trmm(alpha, B(i, j), A(j, j), UpLo::Lower, diagonal_unit, ker.rows(), N - j);
                     ker.store(C(i, j), ker.rows(), N - j);
                 }
 
                 for (; i + 2 * TILE_SIZE <= M; i += 2 * TILE_SIZE)
                 {
                     RegisterMatrix<ET, 2 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                    ker.trmmRightLower(alpha, B(i, j), A(j, j), ker.rows(), N - j);
+                    ker.trmm(alpha, B(i, j), A(j, j), UpLo::Lower, diagonal_unit, ker.rows(), N - j);
                     ker.store(C(i, j), ker.rows(), N - j);
                 }
 
                 for (; i + 1 * TILE_SIZE <= M; i += 1 * TILE_SIZE)
                 {
                     RegisterMatrix<ET, 1 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                    ker.trmmRightLower(alpha, B(i, j), A(j, j), ker.rows(), N - j);
+                    ker.trmm(alpha, B(i, j), A(j, j), UpLo::Lower, diagonal_unit, ker.rows(), N - j);
                     ker.store(C(i, j), ker.rows(), N - j);
                 }
 
@@ -233,7 +230,7 @@ namespace blast
                 if (i < M)
                 {
                     RegisterMatrix<ET, TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                    ker.trmmRightLower(alpha, B(i, j), A(j, j), M - i, N - j);
+                    ker.trmm(alpha, B(i, j), A(j, j), UpLo::Lower, diagonal_unit, M - i, N - j);
                     ker.store(C(i, j), M - i, N - j);
                 }
             }

--- a/include/blast/math/algorithm/Trmm.hpp
+++ b/include/blast/math/algorithm/Trmm.hpp
@@ -169,33 +169,24 @@ namespace blast
                 for (; i + 3 * TILE_SIZE <= M && i + 4 * TILE_SIZE != M; i += 3 * TILE_SIZE)
                 {
                     RegisterMatrix<ET, 3 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                    gemm(ker, N - j, alpha, B(i, j), A(j, j));
-                    /*
-                    ker.trmmRightLower(alpha, ptr<aligned>(B, i, j), ptr<aligned>(A, j, j));
-                    ker.gemm(K, alpha, ptr<aligned>(B, i, j + TILE_SIZE), ptr<aligned>(A, j + TILE_SIZE, j));
-                    */
+                    ker.trmmRightLower(alpha, B(i, j), A(j, j));
+                    gemm(ker, N - j - TILE_SIZE, alpha, B(i, j + TILE_SIZE), A(j + TILE_SIZE, j));
                     ker.store(C(i, j));
                 }
 
                 for (; i + 2 * TILE_SIZE <= M; i += 2 * TILE_SIZE)
                 {
                     RegisterMatrix<ET, 2 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                    gemm(ker, N - j, alpha, B(i, j), A(j, j));
-                    /*
-                    ker.trmmRightLower(alpha, ptr<aligned>(B, i, j), ptr<aligned>(A, j, j));
-                    ker.gemm(K, alpha, ptr<aligned>(B, i, j + TILE_SIZE), ptr<aligned>(A, j + TILE_SIZE, j));
-                    */
+                    ker.trmmRightLower(alpha, B(i, j), A(j, j));
+                    gemm(ker, N - j - TILE_SIZE, alpha, B(i, j + TILE_SIZE), A(j + TILE_SIZE, j));
                     ker.store(C(i, j));
                 }
 
                 for (; i + 1 * TILE_SIZE <= M; i += 1 * TILE_SIZE)
                 {
                     RegisterMatrix<ET, 1 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                    gemm(ker, N - j, alpha, B(i, j), A(j, j));
-                    /*
-                    ker.trmmRightLower(alpha, ptr<aligned>(B, i, j), ptr<aligned>(A, j, j));
-                    ker.gemm(K, alpha, ptr<aligned>(B, i, j + TILE_SIZE), ptr<aligned>(A, j + TILE_SIZE, j));
-                    */
+                    ker.trmmRightLower(alpha, B(i, j), A(j, j));
+                    gemm(ker, N - j - TILE_SIZE, alpha, B(i, j + TILE_SIZE), A(j + TILE_SIZE, j));
                     ker.store(C(i, j));
                 }
 
@@ -203,11 +194,8 @@ namespace blast
                 if (i < M)
                 {
                     RegisterMatrix<ET, TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                    gemm(ker, N - j, alpha, B(i, j), A(j, j), M - i, ker.columns());
-                    /*
-                    ker.trmmRightLower(alpha, ptr<aligned>(B, i, j), ptr<aligned>(A, j, j));
-                    ker.gemm(K, alpha, ptr<aligned>(B, i, j + TILE_SIZE), ptr<aligned>(A, j + TILE_SIZE, j), M - i, ker.columns());
-                    */
+                    ker.trmmRightLower(alpha, B(i, j), A(j, j), M - i, ker.columns());
+                    gemm(ker, N - j - TILE_SIZE, alpha, B(i, j + TILE_SIZE), A(j + TILE_SIZE, j), M - i, ker.columns());
                     ker.store(C(i, j), M - i, ker.columns());
                 }
             }
@@ -223,21 +211,21 @@ namespace blast
                 for (; i + 3 * TILE_SIZE <= M && i + 4 * TILE_SIZE != M; i += 3 * TILE_SIZE)
                 {
                     RegisterMatrix<ET, 3 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                    gemm(ker, N - j, alpha, B(i, j), A(j, j), ker.rows(), N - j);
+                    ker.trmmRightLower(alpha, B(i, j), A(j, j), ker.rows(), N - j);
                     ker.store(C(i, j), ker.rows(), N - j);
                 }
 
                 for (; i + 2 * TILE_SIZE <= M; i += 2 * TILE_SIZE)
                 {
                     RegisterMatrix<ET, 2 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                    gemm(ker, N - j, alpha, B(i, j), A(j, j), ker.rows(), N - j);
+                    ker.trmmRightLower(alpha, B(i, j), A(j, j), ker.rows(), N - j);
                     ker.store(C(i, j), ker.rows(), N - j);
                 }
 
                 for (; i + 1 * TILE_SIZE <= M; i += 1 * TILE_SIZE)
                 {
                     RegisterMatrix<ET, 1 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                    gemm(ker, N - j, alpha, B(i, j), A(j, j), ker.rows(), N - j);
+                    ker.trmmRightLower(alpha, B(i, j), A(j, j), ker.rows(), N - j);
                     ker.store(C(i, j), ker.rows(), N - j);
                 }
 
@@ -245,7 +233,7 @@ namespace blast
                 if (i < M)
                 {
                     RegisterMatrix<ET, TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                    gemm(ker, N - j, alpha, B(i, j), A(j, j), M - i, N - j);
+                    ker.trmmRightLower(alpha, B(i, j), A(j, j), M - i, N - j);
                     ker.store(C(i, j), M - i, N - j);
                 }
             }

--- a/include/blast/math/algorithm/Trmm.hpp
+++ b/include/blast/math/algorithm/Trmm.hpp
@@ -7,8 +7,12 @@
 #include <blast/math/Matrix.hpp>
 #include <blast/math/RegisterMatrix.hpp>
 #include <blast/math/algorithm/Gemm.hpp>
+#include <blast/math/UpLo.hpp>
 #include <blast/system/Tile.hpp>
 #include <blast/system/Inline.hpp>
+#include <blast/util/Exception.hpp>
+
+#include <stdexcept>
 
 
 namespace blast
@@ -67,15 +71,210 @@ namespace blast
             }
         }
     }
-    /// @brief C = alpha * A * B + C; A upper-triangular
+
+
+    /// @brief C = alpha * A * B; A upper- or lower-triangular. Matrix pointer arguments.
+    ///
+    /// See https://netlib.org/lapack/explore-html-3.6.1/d1/d54/group__double__blas__level3_gaf07edfbb2d2077687522652c9e283e1e.html
+    ///
+    /// @tparam MPA matrix pointer type for matrix A
+    /// @tparam MPB matrix pointer type for matrix B
+    /// @tparam MPC matrix pointer type for matrix C
+    ///
+    /// @param M the number of rows of B
+    /// @param N the number of columns of B
+    /// @param alpha the scalar alpha
+    /// @param A pointer to top left element of matrix A
+    /// @param uplo specifies whether the matrix A is an upper or lower triangular
+    /// @param diag specifies whether or not A is unit triangular
+    /// @param B pointer to top left element of matrix B
+    /// @param C pointer to top left element of matrix C
+    ///
+    template <typename ST, typename MPA, typename MPB, typename MPC>
+    requires MatrixPointer<MPA, ST> && MatrixPointer<MPB, ST> && MatrixPointer<MPC, ST>
+        && (StorageOrder_v<MPA> == columnMajor) && (StorageOrder_v<MPC> == columnMajor)
+    inline void trmm(size_t M, size_t N, ST alpha, MPA A, UpLo uplo, bool diag, MPB B, MPC C)
+    {
+        using ET = ST;
+        size_t constexpr TILE_SIZE = TileSize_v<ET>;
+
+        if (diag)
+            BLAST_THROW_EXCEPTION(std::logic_error {"Unit-triangular matrices support not implemented in trmm()"});
+
+        if (uplo == UpLo::Upper)
+        {
+            size_t i = 0;
+
+            // i + 4 * TILE_SIZE != M is to improve performance in case when the remaining number of rows is 4 * TILE_SIZE:
+            // it is more efficient to apply 2 * TILE_SIZE kernel 2 times than 3 * TILE_SIZE + 1 * TILE_SIZE kernel.
+            for (; i + 2 * TILE_SIZE < M && i + 4 * TILE_SIZE != M; i += 3 * TILE_SIZE)
+                detail::trmmLeftUpper_backend<3 * TILE_SIZE, TILE_SIZE>(
+                    M - i, N, alpha, A(i, i), B(i, 0), C(i, 0));
+
+            for (; i + 1 * TILE_SIZE < M; i += 2 * TILE_SIZE)
+                detail::trmmLeftUpper_backend<2 * TILE_SIZE, TILE_SIZE>(
+                    M - i, N, alpha, A(i, i), B(i, 0), C(i, 0));
+
+            for (; i + 0 * TILE_SIZE < M; i += 1 * TILE_SIZE)
+                detail::trmmLeftUpper_backend<1 * TILE_SIZE, TILE_SIZE>(
+                    M - i, N, alpha, A(i, i), B(i, 0), C(i, 0));
+        }
+        else
+        {
+            BLAST_THROW_EXCEPTION(std::logic_error {"Left product with lower-triangular matrices not implemented in trmm()"});
+        }
+    }
+
+
+    /// @brief C = alpha * B * A; A upper- or lower-triangular. Matrix pointer arguments.
+    ///
+    /// See https://netlib.org/lapack/explore-html-3.6.1/d1/d54/group__double__blas__level3_gaf07edfbb2d2077687522652c9e283e1e.html
+    ///
+    /// @tparam MPB matrix pointer type for matrix B
+    /// @tparam MPA matrix pointer type for matrix A
+    /// @tparam MPC matrix pointer type for matrix C
+    ///
+    /// @param M the number of rows of B
+    /// @param N the number of columns of B
+    /// @param alpha the scalar alpha
+    /// @param B pointer to top left element of matrix B
+    /// @param A pointer to top left element of matrix A
+    /// @param uplo specifies whether the matrix A is an upper or lower triangular
+    /// @param diag specifies whether or not A is unit triangular
+    /// @param C pointer to top left element of matrix C
+    ///
+    template <typename ST, typename MPB, typename MPA, typename MPC>
+    requires MatrixPointer<MPB, ST> && MatrixPointer<MPA, ST> && MatrixPointer<MPC, ST>
+        && (StorageOrder_v<MPB> == columnMajor) && (StorageOrder_v<MPC> == columnMajor)
+    inline void trmm(size_t M, size_t N, ST alpha, MPB B, MPA A, UpLo uplo, bool diag, MPC C)
+    {
+        using ET = ST;
+        size_t constexpr TILE_SIZE = TileSize_v<ET>;
+
+        if (diag)
+            BLAST_THROW_EXCEPTION(std::logic_error {"Unit-triangular matrices support not implemented in trmm()"});
+
+        if (uplo == UpLo::Lower)
+        {
+            size_t j = 0;
+
+            // Main part
+            for (; j + TILE_SIZE <= N; j += TILE_SIZE)
+            {
+                // size_t const K = N - j - TILE_SIZE;
+                size_t i = 0;
+
+                // i + 4 * TILE_SIZE != M is to improve performance in case when the remaining number of rows is 4 * TILE_SIZE:
+                // it is more efficient to apply 2 * TILE_SIZE kernel 2 times than 3 * TILE_SIZE + 1 * TILE_SIZE kernel.
+                for (; i + 3 * TILE_SIZE <= M && i + 4 * TILE_SIZE != M; i += 3 * TILE_SIZE)
+                {
+                    RegisterMatrix<ET, 3 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
+                    gemm(ker, N - j, alpha, B(i, j), A(j, j));
+                    /*
+                    ker.trmmRightLower(alpha, ptr<aligned>(B, i, j), ptr<aligned>(A, j, j));
+                    ker.gemm(K, alpha, ptr<aligned>(B, i, j + TILE_SIZE), ptr<aligned>(A, j + TILE_SIZE, j));
+                    */
+                    ker.store(C(i, j));
+                }
+
+                for (; i + 2 * TILE_SIZE <= M; i += 2 * TILE_SIZE)
+                {
+                    RegisterMatrix<ET, 2 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
+                    gemm(ker, N - j, alpha, B(i, j), A(j, j));
+                    /*
+                    ker.trmmRightLower(alpha, ptr<aligned>(B, i, j), ptr<aligned>(A, j, j));
+                    ker.gemm(K, alpha, ptr<aligned>(B, i, j + TILE_SIZE), ptr<aligned>(A, j + TILE_SIZE, j));
+                    */
+                    ker.store(C(i, j));
+                }
+
+                for (; i + 1 * TILE_SIZE <= M; i += 1 * TILE_SIZE)
+                {
+                    RegisterMatrix<ET, 1 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
+                    gemm(ker, N - j, alpha, B(i, j), A(j, j));
+                    /*
+                    ker.trmmRightLower(alpha, ptr<aligned>(B, i, j), ptr<aligned>(A, j, j));
+                    ker.gemm(K, alpha, ptr<aligned>(B, i, j + TILE_SIZE), ptr<aligned>(A, j + TILE_SIZE, j));
+                    */
+                    ker.store(C(i, j));
+                }
+
+                // Bottom side
+                if (i < M)
+                {
+                    RegisterMatrix<ET, TILE_SIZE, TILE_SIZE, columnMajor> ker;
+                    gemm(ker, N - j, alpha, B(i, j), A(j, j), M - i, ker.columns());
+                    /*
+                    ker.trmmRightLower(alpha, ptr<aligned>(B, i, j), ptr<aligned>(A, j, j));
+                    ker.gemm(K, alpha, ptr<aligned>(B, i, j + TILE_SIZE), ptr<aligned>(A, j + TILE_SIZE, j), M - i, ker.columns());
+                    */
+                    ker.store(C(i, j), M - i, ker.columns());
+                }
+            }
+
+
+            // Right side
+            if (j < N)
+            {
+                size_t i = 0;
+
+                // i + 4 * TILE_SIZE != M is to improve performance in case when the remaining number of rows is 4 * TILE_SIZE:
+                // it is more efficient to apply 2 * TILE_SIZE kernel 2 times than 3 * TILE_SIZE + 1 * TILE_SIZE kernel.
+                for (; i + 3 * TILE_SIZE <= M && i + 4 * TILE_SIZE != M; i += 3 * TILE_SIZE)
+                {
+                    RegisterMatrix<ET, 3 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
+                    gemm(ker, N - j, alpha, B(i, j), A(j, j), ker.rows(), N - j);
+                    ker.store(C(i, j), ker.rows(), N - j);
+                }
+
+                for (; i + 2 * TILE_SIZE <= M; i += 2 * TILE_SIZE)
+                {
+                    RegisterMatrix<ET, 2 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
+                    gemm(ker, N - j, alpha, B(i, j), A(j, j), ker.rows(), N - j);
+                    ker.store(C(i, j), ker.rows(), N - j);
+                }
+
+                for (; i + 1 * TILE_SIZE <= M; i += 1 * TILE_SIZE)
+                {
+                    RegisterMatrix<ET, 1 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
+                    gemm(ker, N - j, alpha, B(i, j), A(j, j), ker.rows(), N - j);
+                    ker.store(C(i, j), ker.rows(), N - j);
+                }
+
+                // Bottom-right corner
+                if (i < M)
+                {
+                    RegisterMatrix<ET, TILE_SIZE, TILE_SIZE, columnMajor> ker;
+                    gemm(ker, N - j, alpha, B(i, j), A(j, j), M - i, N - j);
+                    ker.store(C(i, j), M - i, N - j);
+                }
+            }
+        }
+        else
+        {
+            BLAST_THROW_EXCEPTION(std::logic_error {"Right product with upper-triangular matrices not implemented in trmm()"});
+        }
+    }
+
+
+    /// @brief C = alpha * A * B; A upper- or lower-triangular. Matrix arguments.
+    ///
+    /// See https://netlib.org/lapack/explore-html-3.6.1/d1/d54/group__double__blas__level3_gaf07edfbb2d2077687522652c9e283e1e.html
+    ///
+    /// @tparam MT1 matrix type for matrix A
+    /// @tparam MT2 matrix type for matrix B
+    /// @tparam MT3 matrix type for matrix C
+    ///
+    /// @param alpha the scalar alpha
+    /// @param A matrix A
+    /// @param uplo specifies whether the matrix A is an upper or lower triangular
+    /// @param diag specifies whether or not A is unit triangular
+    /// @param B matrix B
+    /// @param C matrix C
     ///
     template <typename ST, typename MT1, typename MT2, typename MT3>
     requires Matrix<MT1, ST> && Matrix<MT2, ST> && Matrix<MT3, ST>
-        && (StorageOrder_v<MT1> == columnMajor) && (StorageOrder_v<MT3> == columnMajor)
-    inline void trmmLeftUpper(
-        ST alpha,
-        MT1 const& A, MT2 const& B,
-        MT3& C)
+    inline void trmm(ST alpha, MT1 const& A, UpLo uplo, bool diag, MT2 const& B, MT3& C)
     {
         using ET = ST;
         size_t constexpr TILE_SIZE = TileSize_v<ET>;
@@ -84,41 +283,35 @@ namespace blast
         size_t const N = columns(B);
 
         if (rows(A) != M || columns(A) != M)
-            throw std::invalid_argument {"Matrix sizes do not match"};
+            BLAST_THROW_EXCEPTION(std::invalid_argument {"Matrix sizes do not match"});
 
         if (rows(C) != M || columns(C) != N)
-            throw std::invalid_argument {"Matrix sizes do not match"};
+            BLAST_THROW_EXCEPTION(std::invalid_argument {"Matrix sizes do not match"});
 
-        size_t i = 0;
-
-        // i + 4 * TILE_SIZE != M is to improve performance in case when the remaining number of rows is 4 * TILE_SIZE:
-        // it is more efficient to apply 2 * TILE_SIZE kernel 2 times than 3 * TILE_SIZE + 1 * TILE_SIZE kernel.
-        for (; i + 2 * TILE_SIZE < M && i + 4 * TILE_SIZE != M; i += 3 * TILE_SIZE)
-            detail::trmmLeftUpper_backend<3 * TILE_SIZE, TILE_SIZE>(
-                M - i, N, alpha, ptr<aligned>(A, i, i), ptr<aligned>(B, i, 0), ptr<aligned>(C, i, 0));
-
-        for (; i + 1 * TILE_SIZE < M; i += 2 * TILE_SIZE)
-            detail::trmmLeftUpper_backend<2 * TILE_SIZE, TILE_SIZE>(
-                M - i, N, alpha, ptr<aligned>(A, i, i), ptr<aligned>(B, i, 0), ptr<aligned>(C, i, 0));
-
-        for (; i + 0 * TILE_SIZE < M; i += 1 * TILE_SIZE)
-            detail::trmmLeftUpper_backend<1 * TILE_SIZE, TILE_SIZE>(
-                M - i, N, alpha, ptr<aligned>(A, i, i), ptr<aligned>(B, i, 0), ptr<aligned>(C, i, 0));
+        trmm(M, N, alpha, ptr(A), uplo, diag, ptr(B), ptr(C));
     }
 
 
-    /// @brief C = alpha * B * A + C; A lower-triangular
+    /// @brief C = alpha * B * A + C; A lower-triangular. Matrix arguments.
+    ///
+    /// See https://netlib.org/lapack/explore-html-3.6.1/d1/d54/group__double__blas__level3_gaf07edfbb2d2077687522652c9e283e1e.html
+    ///
+    /// @tparam MTB matrix type for matrix B
+    /// @tparam MTA matrix type for matrix A
+    /// @tparam MTC matrix type for matrix C
+    ///
+    /// @param alpha the scalar alpha
+    /// @param B matrix B
+    /// @param A matrix A
+    /// @param uplo specifies whether the matrix A is an upper or lower triangular
+    /// @param diag specifies whether or not A is unit triangular
+    /// @param C matrix C
     ///
     template <typename ET, typename MTB, typename MTA, typename MTC>
     requires Matrix<MTB, ET> && Matrix<MTA, ET> && Matrix<MTC, ET>
         && (StorageOrder_v<MTB> == columnMajor) && (StorageOrder_v<MTC> == columnMajor)
-    inline void trmmRightLower(
-        ET alpha,
-        MTB const& B, MTA const& A,
-        MTC& C)
+    inline void trmm(ET alpha, MTB const& B, MTA const& A, UpLo uplo, bool diag, MTC& C)
     {
-        size_t constexpr TILE_SIZE = TileSize_v<ET>;
-
         size_t const M = rows(B);
         size_t const N = columns(B);
 
@@ -128,98 +321,6 @@ namespace blast
         if (rows(C) != M || columns(C) != N)
             BLAZE_THROW_INVALID_ARGUMENT("Matrix sizes do not match");
 
-        size_t j = 0;
-
-        // Main part
-        for (; j + TILE_SIZE <= N; j += TILE_SIZE)
-        {
-            // size_t const K = N - j - TILE_SIZE;
-            size_t i = 0;
-
-            // i + 4 * TILE_SIZE != M is to improve performance in case when the remaining number of rows is 4 * TILE_SIZE:
-            // it is more efficient to apply 2 * TILE_SIZE kernel 2 times than 3 * TILE_SIZE + 1 * TILE_SIZE kernel.
-            for (; i + 3 * TILE_SIZE <= M && i + 4 * TILE_SIZE != M; i += 3 * TILE_SIZE)
-            {
-                RegisterMatrix<ET, 3 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-				gemm(ker, N - j, alpha, ptr<aligned>(B, i, j), ptr<aligned>(A, j, j));
-				/*
-                ker.trmmRightLower(alpha, ptr<aligned>(B, i, j), ptr<aligned>(A, j, j));
-                ker.gemm(K, alpha, ptr<aligned>(B, i, j + TILE_SIZE), ptr<aligned>(A, j + TILE_SIZE, j));
-				*/
-                ker.store(ptr<aligned>(C, i, j));
-            }
-
-            for (; i + 2 * TILE_SIZE <= M; i += 2 * TILE_SIZE)
-            {
-                RegisterMatrix<ET, 2 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-				gemm(ker, N - j, alpha, ptr<aligned>(B, i, j), ptr<aligned>(A, j, j));
-				/*
-                ker.trmmRightLower(alpha, ptr<aligned>(B, i, j), ptr<aligned>(A, j, j));
-                ker.gemm(K, alpha, ptr<aligned>(B, i, j + TILE_SIZE), ptr<aligned>(A, j + TILE_SIZE, j));
-				*/
-                ker.store(ptr<aligned>(C, i, j));
-            }
-
-            for (; i + 1 * TILE_SIZE <= M; i += 1 * TILE_SIZE)
-            {
-                RegisterMatrix<ET, 1 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-				gemm(ker, N - j, alpha, ptr<aligned>(B, i, j), ptr<aligned>(A, j, j));
-				/*
-                ker.trmmRightLower(alpha, ptr<aligned>(B, i, j), ptr<aligned>(A, j, j));
-                ker.gemm(K, alpha, ptr<aligned>(B, i, j + TILE_SIZE), ptr<aligned>(A, j + TILE_SIZE, j));
-				*/
-                ker.store(ptr<aligned>(C, i, j));
-            }
-
-            // Bottom side
-            if (i < M)
-            {
-                RegisterMatrix<ET, TILE_SIZE, TILE_SIZE, columnMajor> ker;
-				gemm(ker, N - j, alpha, ptr<aligned>(B, i, j), ptr<aligned>(A, j, j), M - i, ker.columns());
-				/*
-                ker.trmmRightLower(alpha, ptr<aligned>(B, i, j), ptr<aligned>(A, j, j));
-                ker.gemm(K, alpha, ptr<aligned>(B, i, j + TILE_SIZE), ptr<aligned>(A, j + TILE_SIZE, j), M - i, ker.columns());
-				*/
-                ker.store(ptr<aligned>(C, i, j), M - i, ker.columns());
-            }
-        }
-
-
-        // Right side
-        if (j < N)
-        {
-            size_t i = 0;
-
-            // i + 4 * TILE_SIZE != M is to improve performance in case when the remaining number of rows is 4 * TILE_SIZE:
-            // it is more efficient to apply 2 * TILE_SIZE kernel 2 times than 3 * TILE_SIZE + 1 * TILE_SIZE kernel.
-            for (; i + 3 * TILE_SIZE <= M && i + 4 * TILE_SIZE != M; i += 3 * TILE_SIZE)
-            {
-                RegisterMatrix<ET, 3 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                gemm(ker, N - j, alpha, ptr<aligned>(B, i, j), ptr<aligned>(A, j, j), ker.rows(), N - j);
-                ker.store(ptr<aligned>(C, i, j), ker.rows(), N - j);
-            }
-
-            for (; i + 2 * TILE_SIZE <= M; i += 2 * TILE_SIZE)
-            {
-                RegisterMatrix<ET, 2 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                gemm(ker, N - j, alpha, ptr<aligned>(B, i, j), ptr<aligned>(A, j, j), ker.rows(), N - j);
-                ker.store(ptr<aligned>(C, i, j), ker.rows(), N - j);
-            }
-
-            for (; i + 1 * TILE_SIZE <= M; i += 1 * TILE_SIZE)
-            {
-                RegisterMatrix<ET, 1 * TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                gemm(ker, N - j, alpha, ptr<aligned>(B, i, j), ptr<aligned>(A, j, j), ker.rows(), N - j);
-                ker.store(ptr<aligned>(C, i, j), ker.rows(), N - j);
-            }
-
-            // Bottom-right corner
-            if (i < M)
-            {
-                RegisterMatrix<ET, TILE_SIZE, TILE_SIZE, columnMajor> ker;
-                gemm(ker, N - j, alpha, ptr<aligned>(B, i, j), ptr<aligned>(A, j, j), M - i, N - j);
-                ker.store(ptr<aligned>(C, i, j), M - i, N - j);
-            }
-        }
+        trmm(M, N, alpha, ptr(B), ptr(A), uplo, diag, ptr(C));
     }
 }

--- a/include/blast/math/algorithm/Trmm.hpp
+++ b/include/blast/math/algorithm/Trmm.hpp
@@ -86,19 +86,19 @@ namespace blast
     /// @param alpha the scalar alpha
     /// @param A pointer to top left element of matrix A
     /// @param uplo specifies whether the matrix A is an upper or lower triangular
-    /// @param diag specifies whether or not A is unit triangular
+    /// @param diagonal_unit specifies whether or not A is unit triangular
     /// @param B pointer to top left element of matrix B
     /// @param C pointer to top left element of matrix C
     ///
     template <typename ST, typename MPA, typename MPB, typename MPC>
     requires MatrixPointer<MPA, ST> && MatrixPointer<MPB, ST> && MatrixPointer<MPC, ST>
         && (StorageOrder_v<MPA> == columnMajor) && (StorageOrder_v<MPC> == columnMajor)
-    inline void trmm(size_t M, size_t N, ST alpha, MPA A, UpLo uplo, bool diag, MPB B, MPC C)
+    inline void trmm(size_t M, size_t N, ST alpha, MPA A, UpLo uplo, bool diagonal_unit, MPB B, MPC C)
     {
         using ET = ST;
         size_t constexpr TILE_SIZE = TileSize_v<ET>;
 
-        if (diag)
+        if (diagonal_unit)
             BLAST_THROW_EXCEPTION(std::logic_error {"Unit-triangular matrices support not implemented in trmm()"});
 
         if (uplo == UpLo::Upper)
@@ -140,18 +140,18 @@ namespace blast
     /// @param B pointer to top left element of matrix B
     /// @param A pointer to top left element of matrix A
     /// @param uplo specifies whether the matrix A is an upper or lower triangular
-    /// @param diag specifies whether or not A is unit triangular
+    /// @param diagonal_unit specifies whether or not A is unit triangular
     /// @param C pointer to top left element of matrix C
     ///
     template <typename ST, typename MPB, typename MPA, typename MPC>
     requires MatrixPointer<MPB, ST> && MatrixPointer<MPA, ST> && MatrixPointer<MPC, ST>
         && (StorageOrder_v<MPB> == columnMajor) && (StorageOrder_v<MPC> == columnMajor)
-    inline void trmm(size_t M, size_t N, ST alpha, MPB B, MPA A, UpLo uplo, bool diag, MPC C)
+    inline void trmm(size_t M, size_t N, ST alpha, MPB B, MPA A, UpLo uplo, bool diagonal_unit, MPC C)
     {
         using ET = ST;
         size_t constexpr TILE_SIZE = TileSize_v<ET>;
 
-        if (diag)
+        if (diagonal_unit)
             BLAST_THROW_EXCEPTION(std::logic_error {"Unit-triangular matrices support not implemented in trmm()"});
 
         if (uplo == UpLo::Lower)

--- a/include/blast/math/reference/Trmm.hpp
+++ b/include/blast/math/reference/Trmm.hpp
@@ -216,6 +216,6 @@ namespace blast :: reference
             rows(C) != m || columns(C) != n)
             throw std::invalid_argument {"Inconsistent matrix sizes"};
 
-        trmm(m, n, alpha, ptr(B), ptr(A), uplo, diag, ptr(C));
+        reference::trmm(m, n, alpha, ptr(B), ptr(A), uplo, diag, ptr(C));
     }
 }

--- a/include/blast/math/register_matrix/RegisterMatrix.hpp
+++ b/include/blast/math/register_matrix/RegisterMatrix.hpp
@@ -11,6 +11,7 @@
 #include <blast/math/UpLo.hpp>
 #include <blast/math/StorageOrder.hpp>
 #include <blast/util/Types.hpp>
+#include <blast/util/Exception.hpp>
 
 #include <blaze/math/StorageOrder.h>
 #include <blaze/math/Matrix.h>
@@ -20,6 +21,7 @@
 #include <blaze/util/Assert.h>
 #include <blaze/util/StaticAssert.h>
 
+#include <stdexcept>
 #include <type_traits>
 
 
@@ -316,7 +318,7 @@ namespace blast
         void trsm(Side side, UpLo uplo, P A) noexcept;
 
 
-        /// @brief Triangular matrix multiplication
+        /// @brief Left multiplication with a triangular matrix
         ///
         /// Performs the matrix-matrix operation
         ///
@@ -328,15 +330,18 @@ namespace blast
         /// @tparam P1 matrix A pointer type.
         /// @tparam P2 matrix B pointer type.
         ///
-        /// @param a triangular matrix.
+        /// @param alpha the scalar multiplier
+        /// @param a triangular matrix
+        /// @param uplo specifies whether the matrix A is an upper or lower triangular
+        /// @param diagonal_unit specifies whether or not A is unit triangular
         /// @param b general matrix.
         ///
         template <typename P1, typename P2>
         requires MatrixPointer<P1, T> && (P1::storageOrder == columnMajor) && MatrixPointer<P2, T>
-        void trmmLeftUpper(T alpha, P1 a, P2 b) noexcept;
+        void trmm(T alpha, P1 a, UpLo uplo, bool diagonal_unit, P2 b) noexcept;
 
 
-        /// @brief Triangular matrix multiplication
+        /// @brief Right multiplication with a triangular matrix
         ///
         /// Performs the matrix-matrix operation
         ///
@@ -348,15 +353,17 @@ namespace blast
         /// @tparam P1 matrix A pointer type.
         /// @tparam P2 matrix B pointer type.
         ///
-        /// @param b general matrix.
-        /// @param a triangular matrix.
+        /// @param b general matrix
+        /// @param a triangular matrix
+        /// @param uplo specifies whether the matrix A is an upper or lower triangular
+        /// @param diagonal_unit specifies whether or not A is unit triangular
         ///
         template <typename P1, typename P2>
         requires MatrixPointer<P1, T> && (P1::storageOrder == columnMajor) && MatrixPointer<P2, T>
-        void trmmRightLower(T alpha, P1 b, P2 a) noexcept;
+        void trmm(T alpha, P1 b, P2 a, UpLo uplo, bool diagonal_unit) noexcept;
 
 
-        /// @brief Triangular matrix multiplication with a submatrix
+        /// @brief Right multiplication with a triangular submatrix
         ///
         /// Performs the matrix-matrix operation
         ///
@@ -368,12 +375,14 @@ namespace blast
         /// @tparam P1 matrix A pointer type.
         /// @tparam P2 matrix B pointer type.
         ///
-        /// @param b general matrix.
-        /// @param a triangular matrix.
+        /// @param b general matrix
+        /// @param a triangular matrix
+        /// @param uplo specifies whether the matrix A is an upper or lower triangular
+        /// @param diagonal_unit specifies whether or not A is unit triangular
         ///
         template <typename PB, typename PA>
         requires MatrixPointer<PB, T> && (PB::storageOrder == columnMajor) && MatrixPointer<PA, T>
-        void trmmRightLower(T alpha, PB b, PA a, size_t m, size_t n) noexcept;
+        void trmm(T alpha, PB b, PA a, UpLo uplo, bool diagonal_unit, size_t m, size_t n) noexcept;
 
 
     private:
@@ -758,78 +767,49 @@ namespace blast
     template <typename T, size_t M, size_t N, bool SO>
     template <typename P1, typename P2>
     requires MatrixPointer<P1, T> && (P1::storageOrder == columnMajor) && MatrixPointer<P2, T>
-    BLAZE_ALWAYS_INLINE void RegisterMatrix<T, M, N, SO>::trmmLeftUpper(T alpha, P1 a, P2 b) noexcept
+    BLAZE_ALWAYS_INLINE void RegisterMatrix<T, M, N, SO>::trmm(T alpha, P1 a, UpLo uplo, bool diagonal_unit, P2 b) noexcept
     {
-        auto bu = ~b;
+        if (diagonal_unit)
+            BLAST_THROW_EXCEPTION(std::logic_error {"Unit diagonal matrices support not implemented in RegisterMatrix::trmm()"});
 
-        #pragma unroll
-        for (size_t k = 0; k < rows(); ++k)
+        if (uplo == UpLo::Upper)
         {
-            SimdVecType ax[RM];
-            size_t const ii = (k + 1) / SS;
-            size_t const rem = (k + 1) % SS;
+            auto bu = ~b;
 
             #pragma unroll
-            for (size_t i = 0; i < ii; ++i)
-                ax[i] = alpha * a(i * SS, 0).load();
-
-            if (rem)
-                ax[ii] = alpha * a(ii * SS, 0).load(indexSequence<T, Arch>() < rem);
-
-            #pragma unroll
-            for (size_t j = 0; j < N; ++j)
+            for (size_t k = 0; k < rows(); ++k)
             {
-                SimdVecType bx = bu(0, j).broadcast();
+                SimdVecType ax[RM];
+                size_t const ii = (k + 1) / SS;
+                size_t const rem = (k + 1) % SS;
 
                 #pragma unroll
                 for (size_t i = 0; i < ii; ++i)
-                    v_[i][j] = fmadd(ax[i], bx, v_[i][j]);
+                    ax[i] = alpha * a(i * SS, 0).load();
 
                 if (rem)
-                    v_[ii][j] = fmadd(ax[ii], bx, v_[ii][j]);
-            }
-
-            a.hmove(1);
-            bu.vmove(1);
-        }
-    }
-
-
-    template <typename T, size_t M, size_t N, bool SO>
-    template <typename PB, typename PA>
-    requires MatrixPointer<PB, T> && (PB::storageOrder == columnMajor) && MatrixPointer<PA, T>
-    BLAZE_ALWAYS_INLINE void RegisterMatrix<T, M, N, SO>::trmmRightLower(T alpha, PB b, PA a) noexcept
-    {
-        auto au = ~a;
-
-        if constexpr (SO == columnMajor)
-        {
-            #pragma unroll
-            for (size_t k = 0; k < N; ++k)
-            {
-                SimdVecType bx[RM];
+                    ax[ii] = alpha * a(ii * SS, 0).load(indexSequence<T, Arch>() < rem);
 
                 #pragma unroll
-                for (size_t i = 0; i < RM; ++i)
-                    bx[i] = alpha * b(i * SS, 0).load();
-
-                #pragma unroll
-                for (size_t j = 0; j <= k; ++j)
+                for (size_t j = 0; j < N; ++j)
                 {
-                    SimdVecType ax = au(0, j).broadcast();
+                    SimdVecType bx = bu(0, j).broadcast();
 
                     #pragma unroll
-                    for (size_t i = 0; i < RM; ++i)
-                        v_[i][j] = fmadd(bx[i], ax, v_[i][j]);
+                    for (size_t i = 0; i < ii; ++i)
+                        v_[i][j] = fmadd(ax[i], bx, v_[i][j]);
+
+                    if (rem)
+                        v_[ii][j] = fmadd(ax[ii], bx, v_[ii][j]);
                 }
 
-                b.hmove(1);
-                au.vmove(1);
+                a.hmove(1);
+                bu.vmove(1);
             }
         }
         else
         {
-            BLAZE_THROW_LOGIC_ERROR("Not implemented");
+            BLAST_THROW_EXCEPTION(std::logic_error {"Left multiplication with lower-triangular matrix not implemented in RegisterMatrix::trmm()"});
         }
     }
 
@@ -837,7 +817,56 @@ namespace blast
     template <typename T, size_t M, size_t N, bool SO>
     template <typename PB, typename PA>
     requires MatrixPointer<PB, T> && (PB::storageOrder == columnMajor) && MatrixPointer<PA, T>
-    BLAZE_ALWAYS_INLINE void RegisterMatrix<T, M, N, SO>::trmmRightLower(T alpha, PB b, PA a, size_t m, size_t n) noexcept
+    BLAZE_ALWAYS_INLINE void RegisterMatrix<T, M, N, SO>::trmm(T alpha, PB b, PA a, UpLo uplo, bool diagonal_unit) noexcept
+    {
+        if (diagonal_unit)
+            BLAST_THROW_EXCEPTION(std::logic_error {"Unit diagonal matrices support not implemented in RegisterMatrix::trmm()"});
+
+        if (uplo == UpLo::Lower)
+        {
+            auto au = ~a;
+
+            if constexpr (SO == columnMajor)
+            {
+                #pragma unroll
+                for (size_t k = 0; k < N; ++k)
+                {
+                    SimdVecType bx[RM];
+
+                    #pragma unroll
+                    for (size_t i = 0; i < RM; ++i)
+                        bx[i] = alpha * b(i * SS, 0).load();
+
+                    #pragma unroll
+                    for (size_t j = 0; j <= k; ++j)
+                    {
+                        SimdVecType ax = au(0, j).broadcast();
+
+                        #pragma unroll
+                        for (size_t i = 0; i < RM; ++i)
+                            v_[i][j] = fmadd(bx[i], ax, v_[i][j]);
+                    }
+
+                    b.hmove(1);
+                    au.vmove(1);
+                }
+            }
+            else
+            {
+                BLAZE_THROW_LOGIC_ERROR("Not implemented");
+            }
+        }
+        else
+        {
+            BLAST_THROW_EXCEPTION(std::logic_error {"Right multiplication with upper-triangular matrix not implemented in RegisterMatrix::trmm()"});
+        }
+    }
+
+
+    template <typename T, size_t M, size_t N, bool SO>
+    template <typename PB, typename PA>
+    requires MatrixPointer<PB, T> && (PB::storageOrder == columnMajor) && MatrixPointer<PA, T>
+    BLAZE_ALWAYS_INLINE void RegisterMatrix<T, M, N, SO>::trmm(T alpha, PB b, PA a, UpLo uplo, bool diagonal_unit, size_t m, size_t n) noexcept
     {
         // NOTE: this implementation does uses unmasked loads from the matrix a,
         // and therefore will access rows of a beyond m-1.

--- a/include/blast/util/Exception.hpp
+++ b/include/blast/util/Exception.hpp
@@ -7,7 +7,4 @@
 
 #include <boost/throw_exception.hpp>
 
-#include <stdexcept>
-
-
 #define BLAST_THROW_EXCEPTION BOOST_THROW_EXCEPTION

--- a/test/blast/math/dense/TrmmTest.cpp
+++ b/test/blast/math/dense/TrmmTest.cpp
@@ -14,21 +14,14 @@ namespace blast :: testing
 {
     TEST(DenseTrmmTest, testLeftUpper)
     {
-        for (size_t m = 1; m <= 20; m += 1)
-            for (size_t n = 1; n <= 20; n += 1)
+        for (size_t m = 1; m <= 20; ++m)
+            for (size_t n = 1; n <= 20; ++n)
             {
-                // Init matrices
-                //
                 DynamicMatrix<double, columnMajor> A(m, m);
                 DynamicMatrix<double, rowMajor> B(m, n);
                 DynamicMatrix<double, columnMajor> C(m, n);
                 randomize(A);
                 randomize(B);
-
-                // Reset lower-triangular part of A
-                for (size_t i = 0; i < m; ++i)
-                    for (size_t j = 0; j < i; ++j)
-                        A(i, j) = 0.;
 
                 double alpha {};
                 randomize(alpha);
@@ -46,21 +39,14 @@ namespace blast :: testing
 
     TEST(DenseTrmmTest, testRightLower)
     {
-        for (size_t m = 4; m <= 20; m += 1)
-            for (size_t n = 4; n <= 20; n += 1)
+        for (size_t m = 1; m <= 20; ++m)
+            for (size_t n = 1; n <= 20; ++n)
             {
-                // Init matrices
-                //
                 DynamicMatrix<double, columnMajor> A(n, n);
                 DynamicMatrix<double, columnMajor> B(m, n);
                 DynamicMatrix<double, columnMajor> C(m, n);
                 randomize(A);
                 randomize(B);
-
-                // Reset upper-triangular part of A
-                for (size_t i = 0; i < n; ++i)
-                    for (size_t j = i + 1; j < n; ++j)
-                        A(i, j) = 0.;
 
                 double alpha {};
                 randomize(alpha);

--- a/test/blast/math/dense/TrmmTest.cpp
+++ b/test/blast/math/dense/TrmmTest.cpp
@@ -34,7 +34,7 @@ namespace blast :: testing
                 randomize(alpha);
 
                 // Do trmm
-                trmmLeftUpper(alpha, A, B, C);
+                trmm(alpha, A, UpLo::Upper, false, B, C);
 
                 DynamicMatrix<double, columnMajor> C_ref(m, n);
                 reference::trmm(alpha, A, UpLo::Upper, false, B, C_ref);
@@ -66,7 +66,7 @@ namespace blast :: testing
                 randomize(alpha);
 
                 // Do trmm
-                trmmRightLower(alpha, B, A, C);
+                trmm(alpha, B, A, UpLo::Lower, false, C);
 
                 DynamicMatrix<double, columnMajor> C_ref(m, n);
                 reference::trmm(alpha, B, A, UpLo::Lower, false, C_ref);

--- a/test/blast/math/simd/RegisterMatrixTest.cpp
+++ b/test/blast/math/simd/RegisterMatrixTest.cpp
@@ -9,6 +9,7 @@
 #include <blast/math/reference/Ger.hpp>
 #include <blast/math/reference/Gemm.hpp>
 #include <blast/math/reference/Axpy.hpp>
+#include <blast/math/reference/Trmm.hpp>
 #include <blast/math/StaticPanelMatrix.hpp>
 #include <blast/math/dense/StaticMatrix.hpp>
 #include <blast/math/expressions/MatTransExpr.hpp>
@@ -587,25 +588,22 @@ namespace blast :: testing
         using RM = TypeParam;
         using ET = ElementType_t<RM>;
 
-        blaze::DynamicMatrix<ET, columnMajor> A(RM::rows(), RM::rows());
-        blaze::DynamicMatrix<ET, columnMajor> B(RM::rows(), RM::columns());
+        StaticMatrix<ET, RM::rows(), RM::rows(), columnMajor> A;
+        StaticMatrix<ET, RM::rows(), RM::columns(), columnMajor> B, C;
 
-        blaze::randomize(A);
-        blaze::randomize(B);
+        randomize(A);
+        randomize(B);
 
         ET alpha {};
-        blaze::randomize(alpha);
+        randomize(alpha);
 
         RM ker;
         ker.trmm(alpha, ptr(A), UpLo::Upper, false, ptr(B));
 
-        // Reset lower-triangular part
-        for (size_t i = 0; i < A.rows(); ++i)
-            for (size_t j = 0; j < i && j < A.columns(); ++j)
-                blaze::reset(A(i, j));
+        reference::trmm(alpha, A, UpLo::Upper, false, B, C);
 
         // TODO: should be strictly equal?
-        BLAST_ASSERT_APPROX_EQ(ker, alpha * A * B, absTol<ET>(), relTol<ET>());
+        BLAST_ASSERT_APPROX_EQ(ker, C, absTol<ET>(), relTol<ET>());
     }
 
 
@@ -614,25 +612,22 @@ namespace blast :: testing
         using RM = TypeParam;
         using ET = ElementType_t<RM>;
 
-        blaze::DynamicMatrix<ET, columnMajor> A(RM::columns(), RM::columns());
-        blaze::DynamicMatrix<ET, columnMajor> B(RM::rows(), RM::columns());
+        StaticMatrix<ET, RM::columns(), RM::columns(), columnMajor> A;
+        StaticMatrix<ET, RM::rows(), RM::columns(), columnMajor> B, C;
 
-        blaze::randomize(A);
-        blaze::randomize(B);
+        randomize(A);
+        randomize(B);
 
         ET alpha {};
-        blaze::randomize(alpha);
+        randomize(alpha);
 
         RM ker;
         ker.trmm(alpha, ptr(B), ptr(A), UpLo::Lower, false);
 
-        // Reset upper-triangular part
-        for (size_t i = 0; i < A.rows(); ++i)
-            for (size_t j = i + 1; j < A.columns(); ++j)
-                blaze::reset(A(i, j));
+        reference::trmm(alpha, B, A, UpLo::Lower, false, C);
 
         // TODO: should be strictly equal?
-        BLAST_ASSERT_APPROX_EQ(ker, alpha * B * A, absTol<ET>(), relTol<ET>());
+        BLAST_ASSERT_APPROX_EQ(ker, C, absTol<ET>(), relTol<ET>());
     }
 
 

--- a/test/blast/math/simd/RegisterMatrixTest.cpp
+++ b/test/blast/math/simd/RegisterMatrixTest.cpp
@@ -597,7 +597,7 @@ namespace blast :: testing
         blaze::randomize(alpha);
 
         RM ker;
-        ker.trmmLeftUpper(alpha, ptr(A), ptr(B));
+        ker.trmm(alpha, ptr(A), UpLo::Upper, false, ptr(B));
 
         // Reset lower-triangular part
         for (size_t i = 0; i < A.rows(); ++i)
@@ -624,7 +624,7 @@ namespace blast :: testing
         blaze::randomize(alpha);
 
         RM ker;
-        ker.trmmRightLower(alpha, ptr(B), ptr(A));
+        ker.trmm(alpha, ptr(B), ptr(A), UpLo::Lower, false);
 
         // Reset upper-triangular part
         for (size_t i = 0; i < A.rows(); ++i)


### PR DESCRIPTION
No more `trmmLeftUpper()` and `trmmRightLowe()`, just `trmm()`. There are overloads for left and right multiplication differing by the argument order, and there is the `uplo` argument specifying whether the upper or lower-triangular part should be used.